### PR TITLE
Fix memory entry bug and implement token counting

### DIFF
--- a/nomos/llms/base.py
+++ b/nomos/llms/base.py
@@ -197,5 +197,9 @@ class LLMBase:
         """
         raise NotImplementedError("Subclasses should implement this method.")
 
+    def token_counter(self, text: str) -> int:
+        """Count the number of tokens in a string."""
+        return len(text.split())
+
 
 __all__ = ["LLMBase"]

--- a/nomos/llms/openai.py
+++ b/nomos/llms/openai.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel
 
 from .base import LLMBase
 from ..models.agent import Message
-import tiktoken
 
 
 class OpenAI(LLMBase):
@@ -78,6 +77,8 @@ class OpenAI(LLMBase):
 
     def token_counter(self, text: str) -> int:
         """Count tokens using tiktoken for the current model."""
+        import tiktoken
+
         enc = tiktoken.encoding_for_model(self.model)
         return len(enc.encode(text))
 

--- a/nomos/llms/openai.py
+++ b/nomos/llms/openai.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 
 from .base import LLMBase
 from ..models.agent import Message
+import tiktoken
 
 
 class OpenAI(LLMBase):
@@ -74,6 +75,11 @@ class OpenAI(LLMBase):
             **kwargs,
         )
         return comp.choices[0].message.content if comp.choices else ""  # type: ignore
+
+    def token_counter(self, text: str) -> int:
+        """Count tokens using tiktoken for the current model."""
+        enc = tiktoken.encoding_for_model(self.model)
+        return len(enc.encode(text))
 
 
 __all__ = ["OpenAI"]

--- a/nomos/memory/flow.py
+++ b/nomos/memory/flow.py
@@ -96,7 +96,7 @@ class FlowMemory(Memory):
     ) -> None:
         """Enter the flow memory, optionally using previous context."""
         if previous_context:
-            self.context.extend(self._generate_summary(previous_context))
+            self.context.append(self._generate_summary(previous_context))
             self._index()
 
     def _exit(self) -> Summary:

--- a/nomos/memory/summary.py
+++ b/nomos/memory/summary.py
@@ -5,12 +5,9 @@ from typing import List, Optional, Union
 
 from nomos.models.agent import Message, Step, Summary
 
-import tiktoken
-
 from .base import Memory
 from ..constants import PERIODICAL_SUMMARIZATION_SYSTEM_MESSAGE
 from ..llms import LLMBase
-from ..llms.openai import OpenAI
 from ..utils.logging import log_debug
 
 
@@ -61,14 +58,8 @@ class PeriodicalSummarizationMemory(Memory):
         self.preserve_history = preserve_history
 
     def token_counter(self, text: str) -> int:
-        """Count the number of tokens in a string."""
-        enc = (
-            tiktoken.encoding_for_model(self.llm.model)
-            if isinstance(self.llm, OpenAI)
-            else tiktoken.get_encoding("cl100k_base")
-        )
-        tokens = enc.encode(text)
-        return len(tokens)
+        """Count tokens using the underlying LLM's tokenizer."""
+        return self.llm.token_counter(text)
 
     def generate_summary(self, items: List[Union[Message, Summary]]) -> Summary:
         """Generate a summary from a list of items."""

--- a/poetry.lock
+++ b/poetry.lock
@@ -77,9 +77,10 @@ files = [
 name = "certifi"
 version = "2025.1.31"
 description = "Python package for providing Mozilla's CA Bundle."
-optional = false
+optional = true
 python-versions = ">=3.6"
 groups = ["main"]
+markers = "extra == \"cli\" or extra == \"openai\" or extra == \"gemini\" or extra == \"traces\" or extra == \"mistralai\""
 files = [
     {file = "certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"},
     {file = "certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651"},
@@ -101,9 +102,10 @@ files = [
 name = "charset-normalizer"
 version = "3.4.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-optional = false
+optional = true
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "extra == \"cli\" or extra == \"openai\" or extra == \"gemini\" or extra == \"traces\""
 files = [
     {file = "charset_normalizer-3.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:91b36a978b5ae0ee86c394f5a54d6ef44db1de0815eb43de826d41d21e4af3de"},
     {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7461baadb4dc00fd9e0acbe254e3d7d2112e7f92ced2adc96e54ef6501c5f176"},
@@ -730,6 +732,7 @@ files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
 ]
+markers = {main = "extra == \"cli\" or extra == \"openai\" or extra == \"gemini\" or extra == \"traces\" or extra == \"mistralai\""}
 
 [package.extras]
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
@@ -1702,9 +1705,10 @@ ocsp = ["cryptography (>=36.0.1)", "pyopenssl (>=20.0.1)", "requests (>=2.31.0)"
 name = "regex"
 version = "2024.11.6"
 description = "Alternative regular expression module, to replace re."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"openai\""
 files = [
     {file = "regex-2024.11.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ff590880083d60acc0433f9c3f713c51f7ac6ebb9adf889c79a261ecf541aa91"},
     {file = "regex-2024.11.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:658f90550f38270639e83ce492f27d2c8d2cd63805c65a13a14d36ca126753f0"},
@@ -1806,9 +1810,10 @@ files = [
 name = "requests"
 version = "2.32.3"
 description = "Python HTTP for Humans."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"cli\" or extra == \"openai\" or extra == \"gemini\" or extra == \"traces\""
 files = [
     {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
     {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
@@ -2097,9 +2102,10 @@ full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart 
 name = "tiktoken"
 version = "0.9.0"
 description = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"openai\""
 files = [
     {file = "tiktoken-0.9.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:586c16358138b96ea804c034b8acf3f5d3f0258bd2bc3b0227af4af5d622e382"},
     {file = "tiktoken-0.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d9c59ccc528c6c5dd51820b3474402f69d9a9e1d656226848ad68a8d5b2e5108"},
@@ -2214,9 +2220,10 @@ typing-extensions = ">=4.12.0"
 name = "urllib3"
 version = "2.4.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"cli\" or extra == \"openai\" or extra == \"gemini\" or extra == \"traces\""
 files = [
     {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
     {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
@@ -2479,10 +2486,10 @@ type = ["pytest-mypy"]
 cli = ["docker", "rich", "typer"]
 gemini = ["google-genai"]
 mistralai = ["mistralai"]
-openai = ["openai"]
+openai = ["openai", "tiktoken"]
 traces = ["opentelemetry-api", "opentelemetry-exporter-otlp", "opentelemetry-instrumentation", "opentelemetry-sdk"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "ddcd4636c5f24e18c2b9b842d994e6225f17d3b3e758b044bf393cc235efdce5"
+content-hash = "27d6f5a2e04cd8478330320bce35a41b89792dfad707cbfdb0b19f95748e8eec"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "pyyaml (>=6.0.2,<7.0.0)",
     "pydantic-settings (>=2.9.1,<3.0.0)",
     "docstring-parser (>=0.16,<0.17)",
-    "tiktoken (>=0.9.0,<0.10.0)",
 ]
 
 
@@ -30,6 +29,7 @@ cli = [
 ]
 openai = [
     "openai (>=1.76.0,<2.0.0)",
+    "tiktoken (>=0.9.0,<0.10.0)",
 ]
 mistralai = [
     "mistralai (>=1.7.0,<2.0.0)",

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -10,8 +10,10 @@ from nomos.llms.base import LLMBase
 class StubRetriever(Retriver):
     def index(self, items, **kwargs):
         pass
+
     def update(self, items, **kwargs):
         pass
+
     def retrieve(self, query, **kwargs):
         return []
 
@@ -19,10 +21,13 @@ class StubRetriever(Retriver):
 class CounterLLM(LLMBase):
     def __init__(self):
         self.counted = []
+
     def get_output(self, messages, response_format, **kwargs):
         raise NotImplementedError
+
     def generate(self, messages, **kwargs):
         raise NotImplementedError
+
     def token_counter(self, text: str) -> int:
         self.counted.append(text)
         return 42

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,55 @@
+import pytest
+
+from nomos.memory.flow import FlowMemory, Retriver
+from nomos.memory.summary import PeriodicalSummarizationMemory
+from nomos.memory.base import Memory
+from nomos.models.agent import Message, Summary
+from nomos.llms.base import LLMBase
+
+
+class StubRetriever(Retriver):
+    def index(self, items, **kwargs):
+        pass
+    def update(self, items, **kwargs):
+        pass
+    def retrieve(self, query, **kwargs):
+        return []
+
+
+class CounterLLM(LLMBase):
+    def __init__(self):
+        self.counted = []
+    def get_output(self, messages, response_format, **kwargs):
+        raise NotImplementedError
+    def generate(self, messages, **kwargs):
+        raise NotImplementedError
+    def token_counter(self, text: str) -> int:
+        self.counted.append(text)
+        return 42
+
+
+def test_llm_base_token_counter_default(mock_llm):
+    assert mock_llm.token_counter("hello world") == 2
+
+
+def test_periodical_memory_token_counter_uses_llm():
+    llm = CounterLLM()
+    mem = PeriodicalSummarizationMemory(llm=llm)
+    assert mem.token_counter("abc") == 42
+    assert llm.counted == ["abc"]
+
+
+def test_flow_memory_enter_appends_summary():
+    llm = CounterLLM()
+    memory = FlowMemory.__new__(FlowMemory)
+    Memory.__init__(memory)
+    memory.llm = llm
+    memory.retriever = StubRetriever()
+    memory.context = []
+    memory._generate_summary = lambda items: Summary(summary=["sum"])
+
+    previous = [Message(role="user", content="hi")]
+    memory._enter(previous)
+
+    assert len(memory.context) == 1
+    assert isinstance(memory.context[0], Summary)


### PR DESCRIPTION
## Summary
- fix FlowMemory `_enter` to append generated summaries
- add default `token_counter` to `LLMBase`
- implement tiktoken-based `token_counter` in `OpenAI` LLM
- delegate token counting to the LLM in `PeriodicalSummarizationMemory`
- test memory behaviour and token counting

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841481be5048332880ac359a8b33039