### PR TITLE
Add tests for utils and tracing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,11 +17,23 @@ class MockLLM(LLMBase):
         """Initialize mock LLM."""
         self.response = None
         self.messages_received = []
+        self._generate_response = None
 
     def set_response(self, response: BaseModel):
         """Set the responses that the mock LLM will return."""
         log_error(f"Setting mock response: {response}")
         self.response = response
+
+    def set_generate_response(self, response: str) -> None:
+        """Set the response returned by ``generate``."""
+        self._generate_response = response
+
+    def generate(self, messages: List[Message], **kwargs: dict) -> str:
+        """Return a preset string response and capture messages."""
+        self.messages_received = messages
+        if self._generate_response is None:
+            raise ValueError("No generate response available")
+        return self._generate_response
 
     def get_output(
         self, messages: List[Message], response_format: BaseModel, **kwargs: dict

--- a/tests/test_flow_utils.py
+++ b/tests/test_flow_utils.py
@@ -1,0 +1,47 @@
+"""Tests for nomos.utils.flow_utils helper functions."""
+
+from nomos.config import AgentConfig
+from nomos.models.agent import Step, Route
+from nomos.models.flow import FlowConfig
+from nomos.utils import flow_utils
+
+
+def _build_config():
+    steps = [
+        Step(step_id="s1", description="step 1"),
+        Step(step_id="s2", description="step 2"),
+        Step(step_id="s3", description="step 3"),
+    ]
+    flows = [
+        FlowConfig(flow_id="f1", enters=["s1"], exits=["s2"]),
+        FlowConfig(flow_id="f2", enters=["s2"], exits=["s3"]),
+    ]
+    return AgentConfig(name="a", steps=steps, start_step_id="s1", flows=flows)
+
+
+def test_create_flows_from_config():
+    config = _build_config()
+    manager = flow_utils.create_flows_from_config(config)
+
+    assert len(manager.flows) == 2
+    assert "f1" in manager.flows and "f2" in manager.flows
+    # step flow_id gets updated to the last flow it belongs to
+    assert config.steps[1].flow_id == "f2"
+
+
+def test_should_enter_and_exit_flow():
+    manager = flow_utils.create_flows_from_config(_build_config())
+
+    enter_flows = flow_utils.should_enter_flow(manager, "s1")
+    assert [f.flow_id for f in enter_flows] == ["f1"]
+
+    exit_flows = flow_utils.should_exit_flow(manager, "s2")
+    assert [f.flow_id for f in exit_flows] == ["f1"]
+
+
+def test_get_flow_for_step():
+    manager = flow_utils.create_flows_from_config(_build_config())
+
+    flow = flow_utils.get_flow_for_step(manager, "s2")
+    assert flow.flow_id == "f1"
+

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,40 @@
+"""Tests for :class:`AgentGenerator`."""
+
+from unittest.mock import patch
+
+from nomos.utils.generator import (
+    AgentConfiguration,
+    AgentGenerator,
+    Step,
+    Route,
+)
+
+
+def test_agent_generator_generate(monkeypatch, mock_llm):
+    """Verify basic flow of ``AgentGenerator.generate``."""
+
+    mock_llm.set_generate_response("initial plan")
+
+    # Monkeypatch confirmation to stop after first plan
+    monkeypatch.setattr("nomos.utils.generator.Confirm.ask", lambda *_args, **_kw: True)
+
+    # Use dummy LLM by replacing the generator's LLM after init
+    with patch("nomos.utils.generator.LLMConfig.get_llm", return_value=mock_llm):
+        generator = AgentGenerator()
+
+    # Prepare structured response returned by get_output
+    config = AgentConfiguration(
+        name="demo",
+        persona="p",
+        steps=[Step(step_id="s", description="d", routes=[Route(target="s", condition="c")])],
+        start_step_id="s",
+    )
+    mock_llm.set_response(config)
+
+    result = generator.generate("use")
+
+    assert isinstance(result, AgentConfiguration)
+    assert result.name == "demo"
+    # Ensure the LLM received messages for both generate and get_output
+    assert len(mock_llm.messages_received) > 0
+

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,88 @@
+"""Tests for the tracing setup utilities."""
+
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+
+def _load_tracing(monkeypatch):
+    """Return tracing module with fake opentelemetry dependencies."""
+
+    trace_mod = types.ModuleType("opentelemetry.trace")
+    trace_mod.set_tracer_provider = MagicMock()
+    trace_mod.get_tracer_provider = MagicMock()
+    trace_mod.SpanKind = types.SimpleNamespace(INTERNAL=0, CLIENT=1)
+
+    exporter_mod = types.ModuleType(
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter"
+    )
+    exporter_mod.OTLPSpanExporter = MagicMock()
+
+    sdk_trace = types.ModuleType("opentelemetry.sdk.trace")
+    sdk_trace.TracerProvider = MagicMock()
+    sdk_export = types.ModuleType("opentelemetry.sdk.trace.export")
+    sdk_export.BatchSpanProcessor = MagicMock()
+
+    instr_mod = types.ModuleType("opentelemetry.instrumentation.instrumentor")
+    instr_mod.BaseInstrumentor = object
+
+    # Register modules and parents
+    root_mod = types.ModuleType("opentelemetry")
+    root_mod.trace = trace_mod
+    root_mod.instrumentation = types.ModuleType("opentelemetry.instrumentation")
+    root_mod.exporter = types.ModuleType("opentelemetry.exporter")
+    root_mod.sdk = types.ModuleType("opentelemetry.sdk")
+    monkeypatch.setitem(sys.modules, "opentelemetry", root_mod)
+    monkeypatch.setitem(sys.modules, "opentelemetry.trace", trace_mod)
+    monkeypatch.setitem(sys.modules, "opentelemetry.exporter", root_mod.exporter)
+    monkeypatch.setitem(sys.modules, "opentelemetry.exporter.otlp", types.ModuleType("op.exp.otlp"))
+    monkeypatch.setitem(sys.modules, "opentelemetry.exporter.otlp.proto", types.ModuleType("op.exp.otlp.proto"))
+    monkeypatch.setitem(
+        sys.modules,
+        "opentelemetry.exporter.otlp.proto.http",
+        types.ModuleType("op.exp.otlp.proto.http"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+        exporter_mod,
+    )
+    root_mod.instrumentation.instrumentor = instr_mod
+    monkeypatch.setitem(sys.modules, "opentelemetry.instrumentation", root_mod.instrumentation)
+    monkeypatch.setitem(sys.modules, "opentelemetry.instrumentation.instrumentor", instr_mod)
+    root_mod.sdk.trace = sdk_trace
+    root_mod.sdk.trace.export = sdk_export
+    monkeypatch.setitem(sys.modules, "opentelemetry.sdk", root_mod.sdk)
+    monkeypatch.setitem(sys.modules, "opentelemetry.sdk.trace", sdk_trace)
+    monkeypatch.setitem(sys.modules, "opentelemetry.sdk.trace.export", sdk_export)
+
+    tracing = importlib.import_module("nomos.utils.tracing")
+    importlib.reload(tracing)
+    return tracing, trace_mod, exporter_mod, sdk_trace, sdk_export
+
+
+def test_initialize_and_shutdown_tracing(monkeypatch):
+    tracing, trace_mod, exporter_mod, sdk_trace, sdk_export = _load_tracing(monkeypatch)
+
+    tracer_instance = MagicMock()
+    sdk_trace.TracerProvider.return_value = tracer_instance
+    trace_mod.get_tracer_provider.return_value = tracer_instance
+    processor = MagicMock()
+    sdk_export.BatchSpanProcessor.return_value = processor
+
+    instrumentor = MagicMock()
+    monkeypatch.setattr(tracing, "NomosInstrumentor", lambda: instrumentor)
+
+    tracing.initialize_tracing({"tp": 1}, {"ex": 2}, {"sp": 3})
+
+    trace_mod.set_tracer_provider.assert_called_once()
+    sdk_trace.TracerProvider.assert_called_once_with(tp=1)
+    exporter_mod.OTLPSpanExporter.assert_called_once()
+    sdk_export.BatchSpanProcessor.assert_called_once_with(exporter_mod.OTLPSpanExporter.return_value, sp=3)
+    tracer_instance.add_span_processor.assert_called_once_with(processor)
+    instrumentor.instrument.assert_called_once()
+
+    tracing.shutdown_tracing()
+    instrumentor.uninstrument.assert_called_once()
+


### PR DESCRIPTION
## Summary
- extend `MockLLM` with `generate` support for planning
- add unit tests for flow_utils helpers
- add unit test for AgentGenerator basic flow
- add unit test for tracing setup using fake opentelemetry modules

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f583da0083328757bd8c0a751717