### PR TITLE
Support NOMOS logging env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,6 +708,8 @@ The base image supports configuration via environment variables:
 | `ELASTIC_APM_TOKEN` | Elastic APM Token | If tracing enabled |
 | `SERVICE_NAME` | Service name for tracing | No (default: `nomos-agent`) |
 | `SERVICE_VERSION` | Service version for tracing | No (default: `1.0.0`) |
+| `NOMOS_LOG_LEVEL` | Logging level (`DEBUG`, `INFO`, etc.) | No (default: `INFO`) |
+| `NOMOS_ENABLE_LOGGING` | Enable logging (`true`/`false`) | No (default: `false`) |
 
 ### Tracing and Elastic APM Integration
 

--- a/examples/barista/barista.py
+++ b/examples/barista/barista.py
@@ -1,8 +1,8 @@
 import os
 
 # Enable Debugging
-os.environ["SOFIA_LOG_LEVEL"] = "DEBUG"
-os.environ["SOFIA_ENABLE_LOGGING"] = "true"
+os.environ["NOMOS_LOG_LEVEL"] = "DEBUG"
+os.environ["NOMOS_ENABLE_LOGGING"] = "true"
 
 from nomos import *
 from nomos.llms import OpenAI

--- a/examples/barista/barista_with_config.py
+++ b/examples/barista/barista_with_config.py
@@ -1,8 +1,8 @@
 import os
 
 # Enable Debugging
-os.environ["SOFIA_LOG_LEVEL"] = "DEBUG"
-os.environ["SOFIA_ENABLE_LOGGING"] = "true"
+os.environ["NOMOS_LOG_LEVEL"] = "DEBUG"
+os.environ["NOMOS_ENABLE_LOGGING"] = "true"
 
 from nomos import *
 from barista_tools import tools

--- a/nomos/utils/logging.py
+++ b/nomos/utils/logging.py
@@ -4,15 +4,8 @@ import os
 
 from loguru import logger
 
-_log_level_env = os.getenv("NOMOS_LOG_LEVEL")
-if _log_level_env is None:
-    _log_level_env = os.getenv("SOFIA_LOG_LEVEL", "INFO")
-LOG_LEVEL: str = _log_level_env.upper()
-
-_enable_logging_env = os.getenv("NOMOS_ENABLE_LOGGING")
-if _enable_logging_env is None:
-    _enable_logging_env = os.getenv("SOFIA_ENABLE_LOGGING", "false")
-ENABLE_LOGGING: bool = _enable_logging_env.lower() == "true"
+LOG_LEVEL: str = os.getenv("NOMOS_LOG_LEVEL", "INFO").upper()
+ENABLE_LOGGING: bool = os.getenv("NOMOS_ENABLE_LOGGING", "false").lower() == "true"
 
 if ENABLE_LOGGING:
     logger.info(f"Logging is enabled. Log level set to {LOG_LEVEL}.")

--- a/nomos/utils/logging.py
+++ b/nomos/utils/logging.py
@@ -4,8 +4,15 @@ import os
 
 from loguru import logger
 
-LOG_LEVEL = os.getenv("SOFIA_LOG_LEVEL", "INFO").upper()
-ENABLE_LOGGING = os.getenv("SOFIA_ENABLE_LOGGING", "false").lower() == "true"
+_log_level_env = os.getenv("NOMOS_LOG_LEVEL")
+if _log_level_env is None:
+    _log_level_env = os.getenv("SOFIA_LOG_LEVEL", "INFO")
+LOG_LEVEL: str = _log_level_env.upper()
+
+_enable_logging_env = os.getenv("NOMOS_ENABLE_LOGGING")
+if _enable_logging_env is None:
+    _enable_logging_env = os.getenv("SOFIA_ENABLE_LOGGING", "false")
+ENABLE_LOGGING: bool = _enable_logging_env.lower() == "true"
 
 if ENABLE_LOGGING:
     logger.info(f"Logging is enabled. Log level set to {LOG_LEVEL}.")


### PR DESCRIPTION
## Summary
- support `NOMOS_LOG_LEVEL` and `NOMOS_ENABLE_LOGGING`
- update examples to use new variables
- document new environment variables

## Testing
- `pre-commit run --files nomos/utils/logging.py examples/barista/barista.py examples/barista/barista_with_config.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f56c224c83328a06842be4157e97