### PR TITLE
Refactor decision model outputs

### DIFF
--- a/docs/docs/content/docs/api/rest-api.mdx
+++ b/docs/docs/content/docs/api/rest-api.mdx
@@ -54,7 +54,9 @@ Creates a new agent session.
   "session_id": "uuid-string",
   "message": {
     "action": "answer | ask | tool_call | move",
-    "input": "Agent's response text"
+    "response": "Agent's response text",
+    "tool_call": null,
+    "step_transition": null
   }
 }
 ```
@@ -115,7 +117,9 @@ Creates a new agent session.
 {
   "response": {
     "action": "answer | ask | tool_call | move",
-    "input": "Agent's response text"
+    "response": "Agent's response text",
+    "tool_call": null,
+    "step_transition": null
   },
   "tool_output": null,
   "session_data": {

--- a/examples/barista/barista_with_config.py
+++ b/examples/barista/barista_with_config.py
@@ -20,7 +20,7 @@ user_input = None
 while True:
     decision, _ = sess.next(user_input)
     if decision.action.value in [Action.ASK.value, Action.ANSWER.value]:
-        user_input = input(f"Assistant: {decision.input}\nYou: ")
+        user_input = input(f"Assistant: {decision.response}\nYou: ")
     elif decision.action.value == Action.END.value:
         print("Session ended.")
         break

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -112,7 +112,7 @@ def test_tool_usage(basic_agent, test_tool_0, test_tool_1):
     tool_response = tool_model(
         reasoning=["Need to use test tool"],
         action=Action.TOOL_CALL.value,
-        response={
+        tool_call={
             "tool_name": "test_tool",
             "tool_kwargs": {"arg0": "test_arg"},
         },
@@ -126,7 +126,7 @@ def test_tool_usage(basic_agent, test_tool_0, test_tool_1):
     assert session.llm.messages_received[1].role == "user"
     assert "Use the tool" in session.llm.messages_received[1].content
     assert decision.action.value == Action.TOOL_CALL.value
-    assert decision.response.tool_name == "test_tool"
+    assert decision.tool_call.tool_name == "test_tool"
     assert tool_result == "Test tool 0 response: test_arg"
 
     # Verify tool message in history
@@ -154,7 +154,7 @@ def test_pkg_tool_usage(basic_agent, test_tool_0, test_tool_1):
     tool_response = tool_model(
         reasoning=["Need to use combinations tool"],
         action=Action.TOOL_CALL.value,
-        response={
+        tool_call={
             "tool_name": "combinations",
             "tool_kwargs": {"iterable": "abc", "r": 2},
         },
@@ -188,7 +188,7 @@ def test_invalid_tool_args(basic_agent, test_tool_0, test_tool_1):
     invalid_response = tool_model(
         action=Action.TOOL_CALL.value,
         reasoning=["Testing invalid args"],
-        response={
+        tool_call={
             "tool_name": "test_tool",
             "tool_kwargs": {"arg1": "value"},  # Invalid argument
         },


### PR DESCRIPTION
## Summary
- split decision model output fields for response, step transition and tool calls
- update core session logic for new fields
- adapt tests and docs to match new Decision model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684352a05fb88332b471019a95de5936