### PR TITLE
Allow WebSocket session creation

### DIFF
--- a/docs/docs/content/docs/api/websocket.mdx
+++ b/docs/docs/content/docs/api/websocket.mdx
@@ -5,13 +5,13 @@ description: Documentation for SOFIA's WebSocket API endpoints
 
 SOFIA provides a WebSocket API for real-time bidirectional communication with agents. This allows for interactive sessions where the client can send messages and receive responses in real time.
 
-Make sure to create a session before using the Rest API's `POST /session` endpoint.
+If you connect without a session ID, the server will create a new session automatically and return the generated `session_id` in the first message.
 
 ### WebSocket Endpoint
 
 #### WebSocket Connection
 
-`WS /ws/{session_id}`
+`WS /ws` or `WS /ws/{session_id}`
 
 ##### Query Parameters
 | Parameter | Type    | Description                                      |
@@ -32,3 +32,16 @@ or
   "close": true
 }
 ```
+
+##### Message Format (Server to Client)
+```json
+{
+  "session_id": "uuid-string",
+  "message": {
+    "action": "answer | ask | tool_call | move",
+    "input": "Agent response text"
+  }
+}
+```
+
+Send `{ "close": true }` to close the connection gracefully.


### PR DESCRIPTION
## Summary
- allow optional session id for WebSocket connections and create session when absent
- document `/ws` endpoint and automatic session creation

## Testing
- `pre-commit run --files nomos/api/app.py docs/docs/content/docs/api/websocket.mdx`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68435180d5cc8332ad7b13ec989ef871