### PR TITLE
Add py.typed for typing support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - Your security fixes here. -->
 
+## [Unreleased]
+
+### Added
+- Included `py.typed` marker for type checking support.
+
 ## [0.2.1] - 2025-06-06
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,10 @@ testpaths = [
     "tests",
 ]
 
+[tool.poetry]
+packages = [{ include = "nomos" }]
+include = ["nomos/py.typed"]
+
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.5"


### PR DESCRIPTION
## Summary
- add `py.typed` marker file so Nomos exports typing information
- update build config to include `py.typed`
- document addition in the changelog

## Testing
- `pip install -e .`
- `pip install pytest-cov typer rich`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684455e1a8588332bea4fcd7d9c7a217