### PR TITLE
Fix session store import and add import regression test

### DIFF
--- a/nomos/api/session_store.py
+++ b/nomos/api/session_store.py
@@ -255,9 +255,9 @@ async def create_session_store() -> SessionStore:
     # Try to initialize database connection
     if os.getenv("DATABASE_URL"):
         try:
-            from db import get_session as get_db_session
+            from .db import get_session
 
-            db_session = await get_db_session()
+            db_session = await get_session()
         except Exception as e:
             logger.warning(f"Failed to initialize database: {e}")
 

--- a/tests/test_session_store_import.py
+++ b/tests/test_session_store_import.py
@@ -1,0 +1,34 @@
+"""Regression tests for session store imports."""
+
+import importlib
+import os
+import tempfile
+from pathlib import Path
+
+
+def test_session_store_importable():
+    """Ensure nomos.api.session_store can be imported without errors."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cfg_path = Path(tmpdir) / "config.agent.yaml"
+        cfg_path.write_text(
+            """
+name: test_agent
+persona: You are a test agent
+llm:
+  provider: openai
+  model: gpt-3.5-turbo
+steps:
+  - step_id: start
+    description: Start step
+    routes: []
+    available_tools: []
+start_step_id: start
+"""
+        )
+        os.environ["CONFIG_PATH"] = str(cfg_path)
+        os.environ["OPENAI_API_KEY"] = "sk-test"
+        module = importlib.import_module("nomos.api.session_store")
+        assert hasattr(module, "create_session_store")
+
+
+


### PR DESCRIPTION
## Summary
- fix relative import for `get_session`
- add regression test ensuring `nomos.api.session_store` can be imported

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684493e97e148332a77891f1fc075d59