### PR TITLE
Add TS SDK tests and npm release workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,25 @@
+name: Publish TS SDK
+
+on:
+  push:
+    tags:
+      - 'ts-sdk-v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk/ts
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/sdk-ts-test.yml
+++ b/.github/workflows/sdk-ts-test.yml
@@ -1,0 +1,21 @@
+name: Test TS SDK
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk/ts
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: npm test

--- a/sdk/ts/test/nomosclient.test.ts
+++ b/sdk/ts/test/nomosclient.test.ts
@@ -28,4 +28,27 @@ describe('NomosClient', () => {
     const result = await client.chat(req);
     expect(result).toEqual(resp);
   });
+
+  it('sendMessage posts message content', async () => {
+    const resp: SessionResponse = { session_id: '1', message: { ok: true } };
+    nock(base)
+      .post('/session/1/message', { content: 'hello' } as unknown as DataMatcherMap)
+      .reply(200, resp);
+    const result = await client.sendMessage('1', 'hello');
+    expect(result).toEqual(resp);
+  });
+
+  it('endSession deletes session', async () => {
+    const resp = { message: 'ended' };
+    nock(base).delete('/session/1').reply(200, resp);
+    const result = await client.endSession('1');
+    expect(result).toEqual(resp);
+  });
+
+  it('getSessionHistory returns history', async () => {
+    const resp = { session_id: '1', history: [{ content: 'hi' }] };
+    nock(base).get('/session/1/history').reply(200, resp);
+    const result = await client.getSessionHistory('1');
+    expect(result).toEqual(resp);
+  });
 });


### PR DESCRIPTION
## Summary
- add comprehensive tests for the TypeScript SDK
- publish the TS SDK to npm with `ts-sdk-v*` tags
- run TS SDK tests in CI

## Testing
- `npm test` in `sdk/ts`
- `poetry run pytest` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6846cc5639108332ac6a0ec6913f72c5