### PR TITLE
Add preview chat panel to visual builder

### DIFF
--- a/tools/visual-builder/src/components/FlowBuilder.tsx
+++ b/tools/visual-builder/src/components/FlowBuilder.tsx
@@ -22,6 +22,7 @@ import { FlowProvider } from '../context/FlowContext';
 import { NodeEditDialogs } from './dialogs/NodeEditDialogs';
 import { FlowGroupEditDialog } from './dialogs/FlowGroupEditDialog';
 import { ExportImportDialog } from './dialogs/ExportImportDialog';
+import { ChatPreviewDialog } from './dialogs/ChatPreviewDialog';
 import { KeyboardShortcuts } from './KeyboardShortcuts';
 import { SearchFilter } from './SearchFilter';
 import { autoArrangeNodes } from '../utils/autoArrange';
@@ -569,6 +570,7 @@ export default function FlowBuilder() {
     data: FlowGroupData;
   } | null>(null);
   const [showExportImportDialog, setShowExportImportDialog] = useState(false);
+  const [showPreviewDialog, setShowPreviewDialog] = useState(false);
   const [agentName, setAgentName] = useState('my-agent');
   const [persona, setPersona] = useState('A helpful assistant');
   const [contextMenu, setContextMenu] = useState<{
@@ -705,6 +707,10 @@ export default function FlowBuilder() {
     setAgentName('my-agent');
     setPersona('A helpful assistant');
   }, [setNodesWithUndo, setEdges]);
+
+  const handlePreview = useCallback(() => {
+    setShowPreviewDialog(true);
+  }, []);
 
   const handleImportFlow = useCallback((mergeResult: any) => {
     // Add imported nodes alongside existing ones using merge import
@@ -1263,6 +1269,7 @@ export default function FlowBuilder() {
               onExportYaml={handleExportYaml}
               onImportYaml={handleImportYaml}
               onNewConfig={handleNewConfig}
+              onPreview={handlePreview}
             />
           </div>
 
@@ -1359,6 +1366,15 @@ export default function FlowBuilder() {
           agentName={agentName}
           persona={persona}
           onAgentConfigChange={handleAgentConfigChange}
+        />
+
+        <ChatPreviewDialog
+          open={showPreviewDialog}
+          onClose={() => setShowPreviewDialog(false)}
+          nodes={nodes}
+          edges={edges}
+          agentName={agentName}
+          persona={persona}
         />
 
         <KeyboardShortcuts />

--- a/tools/visual-builder/src/components/Toolbar.tsx
+++ b/tools/visual-builder/src/components/Toolbar.tsx
@@ -32,6 +32,7 @@ interface ToolbarProps {
   onExportYaml?: () => void;
   onImportYaml?: () => void;
   onNewConfig?: () => void;
+  onPreview?: () => void;
 }
 
 export function Toolbar({
@@ -49,6 +50,7 @@ export function Toolbar({
   onExportYaml,
   onImportYaml,
   onNewConfig,
+  onPreview,
 }: ToolbarProps) {
   return (
     <div className="flex items-center gap-2 bg-white border border-gray-200 rounded-lg p-2 shadow-sm">
@@ -168,7 +170,7 @@ export function Toolbar({
 
       {/* Actions */}
       <div className="flex items-center gap-1">
-        <Button variant="default" size="sm" className="h-8 px-3">
+        <Button variant="default" size="sm" className="h-8 px-3" onClick={onPreview}>
           <Play className="w-3 h-3 mr-1" />
           Preview
         </Button>

--- a/tools/visual-builder/src/components/dialogs/ChatPreviewDialog.tsx
+++ b/tools/visual-builder/src/components/dialogs/ChatPreviewDialog.tsx
@@ -1,0 +1,98 @@
+import { useState, useEffect, useRef } from 'react';
+import type { Node, Edge } from '@xyflow/react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../ui/dialog';
+import { Label } from '../ui/label';
+import { Input } from '../ui/input';
+import { Textarea } from '../ui/textarea';
+import { Button } from '../ui/button';
+import { startAgent, sendMessage, stopAgent } from '../../lib/pyAgent';
+import { exportToYaml } from '../../utils/nomosYaml';
+
+interface ChatPreviewDialogProps {
+  open: boolean;
+  onClose: () => void;
+  nodes: Node[];
+  edges: Edge[];
+  agentName: string;
+  persona: string;
+}
+
+export function ChatPreviewDialog({ open, onClose, nodes, edges, agentName, persona }: ChatPreviewDialogProps) {
+  const [provider, setProvider] = useState('openai');
+  const [model, setModel] = useState('gpt-3.5-turbo');
+  const [envText, setEnvText] = useState('');
+  const [messages, setMessages] = useState<{ role: string; content: string }[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const parseEnv = (text: string) => {
+    const env: Record<string, string> = {};
+    text.split('\n').forEach(line => {
+      const [k, v] = line.split('=');
+      if (k && v) env[k.trim()] = v.trim();
+    });
+    return env;
+  };
+
+  const start = () => {
+    const yaml = exportToYaml(nodes, edges, agentName, persona).yaml;
+    startAgent(yaml, { provider, model }, parseEnv(envText));
+  };
+
+  useEffect(() => {
+    if (open) {
+      setMessages([]);
+      start();
+    } else {
+      stopAgent();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+
+  const handleSave = () => {
+    start();
+  };
+
+  const handleSend = async () => {
+    const msg = inputRef.current?.value || '';
+    if (!msg) return;
+    setMessages(prev => [...prev, { role: 'user', content: msg }]);
+    const reply = await sendMessage(msg).catch(() => 'Error');
+    setMessages(prev => [...prev, { role: 'assistant', content: reply }]);
+    if (inputRef.current) inputRef.current.value = '';
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-xl w-full">
+        <DialogHeader>
+          <DialogTitle>Preview Chat</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>LLM Provider</Label>
+            <Input value={provider} onChange={e => setProvider(e.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label>Model</Label>
+            <Input value={model} onChange={e => setModel(e.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label>Environment Variables</Label>
+            <Textarea value={envText} onChange={e => setEnvText(e.target.value)} rows={3} placeholder="KEY=value" />
+          </div>
+          <Button onClick={handleSave}>Save & Restart</Button>
+          <div className="border rounded h-48 overflow-y-auto p-2 bg-gray-50 text-sm space-y-1">
+            {messages.map((m, i) => (
+              <div key={i}><b>{m.role}:</b> {m.content}</div>
+            ))}
+          </div>
+          <div className="flex gap-2">
+            <Input ref={inputRef} placeholder="Type a message" className="flex-grow" />
+            <Button onClick={handleSend}>Send</Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/tools/visual-builder/src/lib/pyAgent.ts
+++ b/tools/visual-builder/src/lib/pyAgent.ts
@@ -1,0 +1,71 @@
+export interface LLMConfig {
+  provider: string;
+  model: string;
+  params?: Record<string, any>;
+}
+
+let pyodide: any = null;
+let loading: Promise<any> | null = null;
+
+async function initPyodide() {
+  if (!loading) {
+    // Lazy load pyodide from CDN
+    // @ts-ignore - remote module has no types
+    loading = import('https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js').then((m: any) => m.loadPyodide({ indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.24.1/full/' }));
+  }
+  pyodide = await loading;
+}
+
+export async function startAgent(
+  yamlConfig: string,
+  llm: LLMConfig,
+  env: Record<string, string>
+) {
+  await initPyodide();
+  if (!pyodide) return;
+
+  await pyodide.loadPackage('micropip');
+  await pyodide.runPythonAsync(
+    `import micropip\nawait micropip.install('nomos')`
+  );
+
+  for (const [k, v] of Object.entries(env)) {
+    const escaped = v.replace(/'/g, "\\'");
+    pyodide.runPython(`import os; os.environ['${k}'] = '${escaped}'`);
+  }
+
+  pyodide.globals.set('yaml_config', yamlConfig);
+  pyodide.globals.set('llm_provider', llm.provider);
+  pyodide.globals.set('llm_model', llm.model);
+  pyodide.globals.set('llm_params', llm.params || {});
+
+  const script = `
+import os, yaml, nomos
+from nomos.llms import LLMConfig
+
+data = yaml.safe_load(yaml_config)
+server_data = data.get('server', {})
+if isinstance(server_data, dict):
+    expanded = {k: (os.getenv(v[1:], v) if isinstance(v, str) and v.startswith('$') else v) for k, v in server_data.items()}
+    data['server'] = expanded
+
+config = nomos.AgentConfig(**data)
+config.llm = LLMConfig(provider=llm_provider, model=llm_model, kwargs=llm_params)
+agent = nomos.Agent.from_config(config)
+session = agent.create_session()
+`;
+
+  await pyodide.runPythonAsync(script);
+}
+
+export async function sendMessage(message: string): Promise<string> {
+  if (!pyodide) throw new Error('Agent not started');
+  pyodide.globals.set('user_msg', message);
+  const resp = await pyodide.runPythonAsync(`decision, _ = session.next(user_msg)\nstr(decision)`);
+  return resp as string;
+}
+
+export function stopAgent() {
+  pyodide = null;
+  loading = null;
+}


### PR DESCRIPTION
## Summary
- hook PreviewChatDialog into FlowBuilder with config and nodes
- start agent from YAML config in pyodide
- generate YAML for preview from builder state

## Testing
- `npm run build` in `tools/visual-builder`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d2b2850948332939acc48e7249b2f