### PR TITLE
Add visual builder backend

### DIFF
--- a/tools/visual-builder/backend/Dockerfile
+++ b/tools/visual-builder/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/tools/visual-builder/backend/main.py
+++ b/tools/visual-builder/backend/main.py
@@ -1,0 +1,96 @@
+import atexit
+import os
+import subprocess
+from typing import Dict, Optional
+
+import requests
+from fastapi import Body, FastAPI, HTTPException
+from pydantic import BaseModel
+
+app = FastAPI()
+
+nomos_process: Optional[subprocess.Popen] = None
+server_port: int = 8000
+
+
+def terminate(proc: subprocess.Popen) -> None:
+    """Terminate a process and its children."""
+    if proc.poll() is not None:
+        return
+    try:
+        import psutil
+
+        ps_proc = psutil.Process(proc.pid)
+        for child in ps_proc.children(recursive=True):
+            child.terminate()
+        ps_proc.terminate()
+        _, alive = psutil.wait_procs([ps_proc], timeout=3)
+        for item in alive:
+            item.kill()
+    except Exception:
+        proc.terminate()
+        try:
+            proc.wait(timeout=3)
+        except Exception:
+            proc.kill()
+
+
+def cleanup() -> None:
+    global nomos_process
+    if nomos_process:
+        terminate(nomos_process)
+        nomos_process = None
+
+
+atexit.register(cleanup)
+
+
+class ResetPayload(BaseModel):
+    yaml: str
+    env: Dict[str, str]
+    port: Optional[int] = None
+
+
+@app.post("/reset")
+def reset(payload: ResetPayload):
+    """Reset the running Nomos server with new configuration."""
+    global nomos_process, server_port
+
+    with open("config.agent.yaml", "w", encoding="utf-8") as fh:
+        fh.write(payload.yaml)
+
+    for key, value in payload.env.items():
+        os.environ[str(key)] = str(value)
+
+    if nomos_process and nomos_process.poll() is None:
+        terminate(nomos_process)
+        nomos_process = None
+
+    port = payload.port or 8000
+    server_port = port
+    cmd = [
+        "nomos",
+        "serve",
+        "--config",
+        "config.agent.yaml",
+        "--port",
+        str(port),
+    ]
+    nomos_process = subprocess.Popen(cmd)
+    return {"status": "started", "port": port}
+
+
+@app.post("/chat")
+def chat(data: dict = Body(...)):
+    """Forward chat requests to the running Nomos server."""
+    if nomos_process is None or nomos_process.poll() is not None:
+        raise HTTPException(status_code=400, detail="Nomos server not running")
+
+    url = f"http://localhost:{server_port}/chat"
+    try:
+        resp = requests.post(url, json=data, timeout=60)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.RequestException as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+

--- a/tools/visual-builder/backend/requirements.txt
+++ b/tools/visual-builder/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+requests
+psutil


### PR DESCRIPTION
## Summary
- install backend requirements for visual builder
- implement FastAPI server wrapper for nomos in tools/visual-builder
- add Dockerfile to run the backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d6d76428083329e2e608542198770