### PR TITLE
Add docker compose for visual builder

### DIFF
--- a/tools/visual-builder/README.md
+++ b/tools/visual-builder/README.md
@@ -1,0 +1,15 @@
+# Visual Builder Development Environment
+
+This directory contains a small backend API and frontend web application used for the Nomos visual builder. You can run both services together using Docker Compose.
+
+## Usage
+
+1. Build and start the containers:
+   ```bash
+   docker compose -f docker.compose.yml up --build
+   ```
+2. Open the builder in your browser at [http://localhost:3000](http://localhost:3000).
+
+The frontend container is built with `VITE_BACKEND_URL` set to `http://backend:8000`, allowing it to communicate with the backend API service.
+
+Stop the stack with `Ctrl+C` and `docker compose down` when you are finished.

--- a/tools/visual-builder/docker.compose.yml
+++ b/tools/visual-builder/docker.compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      args:
+        VITE_BACKEND_URL: http://backend:8000
+    depends_on:
+      - backend
+    ports:
+      - "3000:80"

--- a/tools/visual-builder/frontend/Dockerfile
+++ b/tools/visual-builder/frontend/Dockerfile
@@ -1,0 +1,15 @@
+# Stage 1: build the frontend
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+ARG VITE_BACKEND_URL=http://localhost:8000
+ENV VITE_BACKEND_URL=$VITE_BACKEND_URL
+RUN npm run build
+
+# Stage 2: run a lightweight web server
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- create docker-compose with backend and frontend services
- add frontend Dockerfile for building Vite app
- document how to run the stack

## Testing
- `pre-commit run --files tools/visual-builder/README.md tools/visual-builder/docker.compose.yml tools/visual-builder/frontend/Dockerfile`
- `pytest -k nothing`

------
https://chatgpt.com/codex/tasks/task_e_684dd741816c8332967616ce86ed26aa