### PR TITLE
Update docs for CrewAI/LangChain tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Now no need to pass the `tools` by specifying `-t` flag for each tool file, instead mention them in the agent config file under `tools` key. Check the [example](examples/barista/config.agent.yaml) for more details.
 
+## [0.2.4] - 2025-06-18
+
+### Added
+- Support for external tools via `ToolsConfig.external_tools` allowing the use of
+  Python package functions and CrewAI or LangChain tools.
+- `ToolWrapper` abstraction and `get_tools` helper for consistent tool loading.
+- Utility `convert_camelcase_to_snakecase`.
+- CI installs `crewai[tools]` for integration tests.
+
+### Changed
+- `Tool.from_pkg` now accepts dotted module paths instead of `package:func`
+  syntax and `Step` no longer modifies tool names automatically.
+
 ## [0.2.2] - 2025-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     box-shadow: 0 2px 8px rgba(0,0,0,0.07);
     border: 1px solid #222;
   ">
-    <b>NOMOS v0.2.3 released!</b> | <a href="https://github.com/dowhiledev/nomos/releases" style="color:#fff;text-decoration:underline;">See what's new →</a>
+    <b>NOMOS v0.2.4 released!</b> | <a href="https://github.com/dowhiledev/nomos/releases" style="color:#fff;text-decoration:underline;">See what's new →</a>
   </div>
 </div>
 
@@ -75,7 +75,7 @@
   - [Mistral AI](#mistral-ai)
   - [Google Gemini](#google-gemini)
 - [Configuration](#configuration)
-- [Package Tool Integration](#package-tool-integration)
+ - [External Tool Integration](#external-tool-integration)
 - [Examples](#examples)
   - [Barista Agent](#example-barista-agent)
   - [Financial Planning Assistant](#example-financial-planning-assistant)
@@ -112,6 +112,7 @@ The framework allows you to move from no-code to low-code development, making it
 - **Persona-driven**: Easily set the agent's persona for consistent, branded responses.
 - **Tool integration**: Register Python functions as tools for the agent to call.
 - **Package-based tools**: Reference Python package functions directly using `package_name:function` syntax.
+- **External tool support**: Load CrewAI or LangChain tools, or any Python package function via configuration.
 - **Auto tool documentation**: Tool descriptions and parameter documentation are automatically generated from docstrings.
 - **YAML or Python config**: Configure agents via code or declarative YAML.
 - **Step-level answer models**: Specify an `answer_model` for any step to receive structured (JSON/object) responses.
@@ -272,7 +273,7 @@ nomos run
 
 **Options:**
 - `--config, -c`: Configuration file path (default: `config.agent.yaml`)
-- `--tools, -t`: Python files with tool definitions (can be used multiple times) - **Note: As of v0.2.3, you can now specify tools directly in your agent config file**
+- `--tools, -t`: Python files with tool definitions (can be used multiple times) - **Note: As of v0.2.4, you can now specify tools directly in your agent config file**
 - `--port, -p`: Development server port (default: `8000`)
 - `--verbose, -v`: Enable verbose logging
 
@@ -675,21 +676,25 @@ llm:
 # ...rest of config
 ```
 
-## Package Tool Integration
+## External Tool Integration
 
-NOMOS allows you to reference Python package functions directly using the `package_name:function` syntax:
+NOMOS allows you to reference Python package functions, CrewAI tools, and LangChain tools directly in your configuration.
+
+### Package functions
+
+Use the dotted path to a Python function:
 
 ```python
 # Reference a function from a standard library
 "math:sqrt"                      # Standard library function
 "json:loads"                     # Another standard library function
-"itertools:combinations"         # Complex functions work too!
+"itertools.combinations"         # Functions from built-in modules work too!
 
 # Reference nested module functions
-"package_name:module.submodule.function"
+"package_name.module.submodule.function"
 ```
 
-Benefits of package tool integration:
+Benefits of external tool integration:
 
 1. **No-code/low-code development**: Use existing Python functions without writing wrapper code
 2. **Automatic documentation**: Function docstrings are used to generate tool descriptions and parameter documentation
@@ -701,9 +706,9 @@ Tool parameter descriptions in configuration files take precedence over automati
 
 ## Tool Configuration
 
-### New in v0.2.3: Integrated Tool Configuration
+### New in v0.2.4: Integrated Tool Configuration
 
-As of version 0.2.3, you can now specify tools directly in your agent configuration file instead of relying solely on CLI flags. This provides better organization and easier deployment.
+As of version 0.2.4, you can now specify tools directly in your agent configuration file instead of relying solely on CLI flags. This provides better organization and easier deployment.
 
 #### Configuration-Based Tools
 
@@ -717,12 +722,19 @@ steps:
     # ... step configuration
 start_step_id: start
 
-# Tool configuration - NEW in v0.2.3
+# Tool configuration - NEW in v0.2.4
 tools:
   tool_files:
     - "barista_tools"          # Module name
     - "tools/my_tools.py"      # File path
     - "math:sqrt"              # Package function
+  external_tools:
+    - tag: "@pkg/itertools.combinations"
+      name: "combinations"
+    - tag: "@crewai/FileReadTool"
+      name: "file_read_tool"
+    - tag: "@langchain/google_search"
+      name: "google_search"
   tool_arg_descriptions:
     add_to_cart:
       coffee_type: "Coffee type (e.g., Espresso, Latte, Cappuccino)"

--- a/docs/index.html
+++ b/docs/index.html
@@ -445,7 +445,7 @@
             <div class="flex justify-between items-center h-16">
                 <div class="flex items-center space-x-2">
                     <div class="text-2xl font-bold gradient-text">NOMOS</div>
-                    <span class="bg-gradient-to-r from-indigo-500 to-blue-500 text-white text-xs px-2 py-1 rounded-lg font-medium">v0.2.3</span>
+                    <span class="bg-gradient-to-r from-indigo-500 to-blue-500 text-white text-xs px-2 py-1 rounded-lg font-medium">v0.2.4</span>
                 </div>
 
                 <div class="hidden md:flex items-center space-x-8">
@@ -789,7 +789,7 @@
         </div>
     </section>
 
-    <!-- What's New in 0.2.3 Section -->
+    <!-- What's New in 0.2.4 Section -->
     <section class="py-16 bg-gradient-to-br from-indigo-50 via-white to-blue-50 relative overflow-hidden">
         <!-- Background Pattern -->
         <div class="absolute inset-0 opacity-5">
@@ -800,13 +800,13 @@
             <div class="text-center mb-12">
                 <div class="inline-flex items-center gap-2 bg-gradient-to-r from-indigo-500 to-blue-500 text-white px-4 py-2 rounded-full text-sm font-medium mb-4">
                     <i data-lucide="star" class="w-4 h-4"></i>
-                    What's New in v0.2.3
+                    What's New in v0.2.4
                 </div>
                 <h2 class="text-3xl lg:text-5xl font-bold mb-6">
-                    <span class="gradient-text">Enhanced Testing</span> & <span class="text-highlight">Tool Configuration</span>
+                    <span class="gradient-text">Enhanced Testing</span>, <span class="text-highlight">Tool Configuration</span> & <span class="text-highlight">External Tools</span>
                 </h2>
                 <p class="text-lg text-gray-600 max-w-2xl mx-auto">
-                    This release brings powerful testing capabilities and streamlined tool management to make agent development even more efficient.
+                    This release brings powerful testing capabilities, streamlined tool management, and external tool support for CrewAI and LangChain.
                 </p>
             </div>
 
@@ -841,6 +841,17 @@
                     <h3 class="font-bold text-lg mb-2 text-gray-900">YAML Test Configs</h3>
                     <p class="text-gray-600 text-sm leading-relaxed">
                         Load test configurations from YAML files with <code class="bg-gray-100 px-2 py-1 rounded text-xs">nomos test</code> command.
+                    </p>
+                </div>
+
+                <!-- New Feature 4: External Tools -->
+                <div class="bg-white/80 backdrop-blur-lg rounded-xl p-6 border border-indigo-100 hover:border-indigo-300 transition-all duration-300 hover:shadow-lg hover:-translate-y-1">
+                    <div class="w-12 h-12 bg-gradient-to-br from-cyan-500 to-sky-500 rounded-xl flex items-center justify-center mb-4">
+                        <i data-lucide="tool" class="w-6 h-6 text-white"></i>
+                    </div>
+                    <h3 class="font-bold text-lg mb-2 text-gray-900">CrewAI & LangChain Tools</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed">
+                        Seamlessly integrate ready-made tools from CrewAI or LangChain for powerful agent capabilities.
                     </p>
                 </div>
             </div>
@@ -903,7 +914,7 @@
                     </div>
                     <h3 class="text-xl font-semibold mb-4 text-gray-900">Configuration-Driven</h3>
                     <p class="text-gray-600 leading-relaxed">
-                        <span class="font-medium">YAML or Python</span> configuration. Now in v0.2.3: Integrated tool configuration - define tools directly in your config file.
+                        <span class="font-medium">YAML or Python</span> configuration. Now in v0.2.4: Integrated tool configuration with CrewAI & LangChain tool support.
                     </p>
                 </div>
 
@@ -1024,7 +1035,7 @@
                         </div>
                         <h4 class="font-bold text-lg mb-2 text-gray-900">Advanced Testing & Evaluation</h4>
                         <p class="text-gray-600 leading-relaxed">
-                            New in v0.2.3: Smart assertions with LLM-based evaluation, scenario testing, and YAML-based test configurations. Test agent responses intelligently.
+                            New in v0.2.4: Smart assertions with LLM-based evaluation, scenario testing, and YAML-based test configurations. Test agent responses intelligently.
                         </p>
                     </div>
                 </div>
@@ -1179,7 +1190,7 @@
                                     ✓ Available Now
                                 </span>
                                 <div class="text-right">
-                                    <div class="text-2xl font-bold gradient-text">v0.2.3</div>
+                                    <div class="text-2xl font-bold gradient-text">v0.2.4</div>
                                     <div class="text-sm text-gray-500">Latest Release</div>
                                 </div>
                             </div>
@@ -1199,6 +1210,9 @@
                             </div>
                             <div class="bg-gradient-to-r from-blue-50 to-cyan-50 px-4 py-3 rounded-xl border border-blue-100">
                                 <div class="font-medium text-gray-800">Tool control</div>
+                            </div>
+                            <div class="bg-gradient-to-r from-cyan-50 to-sky-50 px-4 py-3 rounded-xl border border-cyan-100">
+                                <div class="font-medium text-gray-800">External tools</div>
                             </div>
                             <div class="bg-gradient-to-r from-emerald-50 to-teal-50 px-4 py-3 rounded-xl border border-emerald-100">
                                 <div class="font-medium text-gray-800">Session management</div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nomos"
-version = "0.2.3"
+version = "0.2.4"
 description = "Configurable multi-step agent framework for building advanced LLM-powered assistants"
 authors = [
     {name = "chandralegend",email = "irugalbandarachandra@gmail.com"}


### PR DESCRIPTION
## Summary
- document CrewAI & LangChain tool support in README and changelog
- update docs website with 0.2.4 release info and external tool feature

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'nomos')*

------
https://chatgpt.com/codex/tasks/task_e_685279ac813883329a88b0a3945154e6