### PR TITLE
Add developer docs

### DIFF
--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -2,7 +2,7 @@
 
 This guide helps you build agents with a smooth developer experience. Choose the workflow that best fits your team:
 
-- **[Fullcode](fullcode/README.md)** – write steps, tools and tests entirely in Python.
+- **[Full-code](full-code/README.md)** – write steps, tools and tests entirely in Python.
 - **[Less-code](less-code/README.md)** – describe agents in YAML while keeping tools and deep tests in Python.
 - **[No-code](no-code/README.md)** – configure everything in YAML and reuse package tools.
 

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -1,8 +1,12 @@
 # Nomos Developer Documentation
 
-Welcome to the Nomos developer guide. These documents focus on using Nomos to build and operate production‑ready agents.
+This guide helps you build agents with a smooth developer experience. Choose the workflow that best fits your team:
 
-## Sections
+- **[Fullcode](fullcode/README.md)** – write steps, tools and tests entirely in Python.
+- **[Less-code](less-code/README.md)** – describe agents in YAML while keeping tools and deep tests in Python.
+- **[No-code](no-code/README.md)** – configure everything in YAML and reuse package tools.
+
+Additional docs:
 
 - [TLDR](tldr.md)
 - [ELI5 Overview](eli5.md)

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -1,0 +1,15 @@
+# Nomos Developer Documentation
+
+Welcome to the Nomos developer guide. These documents focus on using Nomos to build and operate production‑ready agents.
+
+## Sections
+
+- [TLDR](tldr.md)
+- [ELI5 Overview](eli5.md)
+- [Vision & Inspiration](vision-inspiration.md)
+- [Agent Design](agent-design.md)
+- [Collaboration & Reliability](collaboration.md)
+- [Usage](usage/cli.md)
+  - [Deployment](usage/deployment.md)
+  - [Testing](usage/testing.md)
+- [Roadmap](roadmap.md)

--- a/docs/developer/agent-design.md
+++ b/docs/developer/agent-design.md
@@ -1,5 +1,16 @@
 # Agent Design
 
-Nomos prefers **step based** agents over single prompt interactions. Each step can use tools and routes to the next step. Flows group related steps and keep context.
+Nomos encourages **step-based** flows. Each step has an ID, description, and available tools. You can route to another step based on conditions. Flows group related steps so context stays relevant and transitions are explicit.
 
-Prompt based agents rely on monolithic prompts. Nomos encourages breaking work into discrete steps for reliability and observability.
+Example step definition:
+```yaml
+- step_id: gather_info
+  description: Collect user data
+  available_tools:
+    - ask_database
+  routes:
+    - target: finish
+      condition: Information complete
+```
+
+This structured design improves reliability, observability and lets you test each piece independently.

--- a/docs/developer/agent-design.md
+++ b/docs/developer/agent-design.md
@@ -1,0 +1,5 @@
+# Agent Design
+
+Nomos prefers **step based** agents over single prompt interactions. Each step can use tools and routes to the next step. Flows group related steps and keep context.
+
+Prompt based agents rely on monolithic prompts. Nomos encourages breaking work into discrete steps for reliability and observability.

--- a/docs/developer/collaboration.md
+++ b/docs/developer/collaboration.md
@@ -1,10 +1,12 @@
 # Collaboration & Reliability
 
-Nomos provides built‑in tracing and error handling. Environment variables can enable OpenTelemetry integration:
+Nomos is built for teams. Shared YAML configs make it easy to review changes and track history in version control. The CLI can bootstrap projects so everyone starts from the same template.
+
+For observability, enable tracing with environment variables:
 
 ```
-| `ENABLE_TRACING` | Enable OpenTelemetry tracing (`true`/`false`) |
-| `ELASTIC_APM_SERVER_URL` | Elastic APM server URL |
+| `ENABLE_TRACING`        | Enable OpenTelemetry tracing (`true`/`false`) |
+| `ELASTIC_APM_SERVER_URL`| Elastic APM server URL                      |
 ```
 
-Testing helpers such as `smart_assert` and `ScenarioRunner` let you validate conversations programmatically.
+When an error occurs the agent retries and logs detail to help debugging. Use `ScenarioRunner` and `smart_assert` to automate conversation checks as part of your CI pipeline.

--- a/docs/developer/collaboration.md
+++ b/docs/developer/collaboration.md
@@ -1,0 +1,10 @@
+# Collaboration & Reliability
+
+Nomos provides built‑in tracing and error handling. Environment variables can enable OpenTelemetry integration:
+
+```
+| `ENABLE_TRACING` | Enable OpenTelemetry tracing (`true`/`false`) |
+| `ELASTIC_APM_SERVER_URL` | Elastic APM server URL |
+```
+
+Testing helpers such as `smart_assert` and `ScenarioRunner` let you validate conversations programmatically.

--- a/docs/developer/eli5.md
+++ b/docs/developer/eli5.md
@@ -1,0 +1,3 @@
+# ELI5
+
+Nomos lets you describe how your AI helper should act, one step at a time. You write down the steps and which tools it can use. Nomos then runs those steps and keeps track of the conversation for you.

--- a/docs/developer/eli5.md
+++ b/docs/developer/eli5.md
@@ -1,3 +1,3 @@
 # ELI5
 
-Nomos lets you describe how your AI helper should act, one step at a time. You write down the steps and which tools it can use. Nomos then runs those steps and keeps track of the conversation for you.
+Think of Nomos as instructions for a helpful robot. You break down tasks into small steps and decide what tools the robot may use in each one. Nomos follows those steps and remembers the conversation so it can respond politely and predictably.

--- a/docs/developer/full-code/README.md
+++ b/docs/developer/full-code/README.md
@@ -1,4 +1,4 @@
-# Fullcode Development
+# Full-code Development
 
 In the fullcode workflow you write everything in Python:
 

--- a/docs/developer/fullcode/README.md
+++ b/docs/developer/fullcode/README.md
@@ -1,0 +1,28 @@
+# Fullcode Development
+
+In the fullcode workflow you write everything in Python:
+
+- **Steps and flows** are created with the `Step` and `FlowConfig` classes.
+- **Tools** are regular Python functions registered with the agent.
+- **Tests** use the `smart_assert` helpers directly in Python.
+
+```python
+from nomos import Nomos, Step
+from nomos.testing import smart_assert
+
+# define tools
+def get_time():
+    from datetime import datetime
+    return str(datetime.utcnow())
+
+# define steps
+steps = [
+    Step(step_id="start", description="Tell the time", available_tools=["get_time"])
+]
+
+agent = Nomos(name="clock", llm=None, steps=steps, tools=[get_time], start_step_id="start")
+
+def test_start():
+    decision, *_ = agent.next("time?", {})
+    smart_assert(decision, "Agent tells the time", agent.llm)
+```

--- a/docs/developer/less-code/README.md
+++ b/docs/developer/less-code/README.md
@@ -1,0 +1,35 @@
+# Less-code Development
+
+With the less-code approach you describe the agent in YAML but still write Python tools and deeper tests.
+
+1. **Agent YAML**
+   ```yaml
+   name: math-bot
+   persona: Answers math questions
+   steps:
+     - step_id: start
+       description: Respond to calculations
+       available_tools:
+         - sqrt
+   start_step_id: start
+   ```
+
+2. **Tool module**
+   ```python
+   from math import sqrt
+   def sqrt_tool(x: float) -> float:
+       return sqrt(x)
+   ```
+
+3. **Test config**
+   ```yaml
+   llm:
+     provider: openai
+     model: gpt-4o-mini
+   unit:
+     sqrt:
+       input: "sqrt 4"
+       expectation: "Returns 2"
+   ```
+
+Run the agent with `nomos run --config config.agent.yaml` and run tests using `nomos test -c tests.agent.yaml`.

--- a/docs/developer/no-code/README.md
+++ b/docs/developer/no-code/README.md
@@ -1,0 +1,20 @@
+# No-code Development
+
+In the no-code workflow everything is configured in YAML. You rely on built-in CrewAI or package tools.
+
+- **Agent config** lists steps, flows and tool references using the `pkg` tool wrapper.
+- **Test config** defines unit and scenario tests in YAML.
+
+Example snippet:
+```yaml
+name: support-bot
+persona: Helpful assistant
+steps:
+  - step_id: start
+    description: Answer FAQs
+    available_tools:
+      - crewai.search_web
+start_step_id: start
+```
+
+Run with `nomos serve --config config.agent.yaml`.

--- a/docs/developer/roadmap.md
+++ b/docs/developer/roadmap.md
@@ -1,0 +1,7 @@
+# Roadmap
+
+Nomos is under active development. Follow the open issues on GitHub for upcoming features:
+
+```
+- [Top Feature Requests](https://github.com/dowhiledev/nomos/issues?q=label%3Aenhancement+is%3Aopen+sort%3Areactions-%2B1-desc)
+```

--- a/docs/developer/roadmap.md
+++ b/docs/developer/roadmap.md
@@ -1,7 +1,10 @@
 # Roadmap
 
-Nomos is under active development. Follow the open issues on GitHub for upcoming features:
+Nomos is evolving quickly. Planned areas of improvement include:
 
-```
-- [Top Feature Requests](https://github.com/dowhiledev/nomos/issues?q=label%3Aenhancement+is%3Aopen+sort%3Areactions-%2B1-desc)
-```
+- Richer visual builder and improved CLI scaffolding
+- More built-in tools and tighter integration with CrewAI packages
+- Advanced tracing adapters for popular observability platforms
+- Expanded YAML schema validation and helpful error messages
+
+Follow [open issues](https://github.com/dowhiledev/nomos/issues?q=label%3Aenhancement+is%3Aopen+sort%3Areactions-%2B1-desc) for the latest progress.

--- a/docs/developer/tldr.md
+++ b/docs/developer/tldr.md
@@ -1,3 +1,6 @@
 # TLDR
 
-Nomos is an open‑source framework for defining multi‑step agents. Configure personas, steps and tools in YAML or Python, then run locally or in Docker.
+- **Multi-step agents**: break tasks into steps with clear tool access.
+- **YAML or Python**: choose between fullcode, less-code or no-code workflows.
+- **Built for production**: tracing, error handling and strong testing support.
+- **Runs anywhere**: local development, Docker containers or managed cloud.

--- a/docs/developer/tldr.md
+++ b/docs/developer/tldr.md
@@ -1,0 +1,3 @@
+# TLDR
+
+Nomos is an open‑source framework for defining multi‑step agents. Configure personas, steps and tools in YAML or Python, then run locally or in Docker.

--- a/docs/developer/usage/cli.md
+++ b/docs/developer/usage/cli.md
@@ -1,0 +1,31 @@
+# CLI Quick Reference
+
+Nomos ships with a CLI to bootstrap and run agents.
+
+## Initialize a project
+
+```
+nomos init --directory ./my-bot --name chatbot --template basic
+```
+
+Options include:
+- `--directory, -d`: Project directory
+- `--name, -n`: Agent name
+- `--template, -t`: Template type
+- `--generate, -g`: Generate with AI
+
+## Development server
+
+```
+nomos run
+```
+
+Pass `--config` for a YAML file and `--port` to change the port.
+
+## Production
+
+```
+nomos serve --detach
+```
+
+See the README for full option lists.

--- a/docs/developer/usage/cli.md
+++ b/docs/developer/usage/cli.md
@@ -1,31 +1,29 @@
 # CLI Quick Reference
 
-Nomos ships with a CLI to bootstrap and run agents.
+Nomos provides a `nomos` command with helpful sub‑commands.
 
 ## Initialize a project
-
-```
+```bash
 nomos init --directory ./my-bot --name chatbot --template basic
 ```
+Options:
+- `--directory, -d` project directory
+- `--name, -n` agent name
+- `--template, -t` template type
+- `--generate, -g` let Nomos draft your config
 
-Options include:
-- `--directory, -d`: Project directory
-- `--name, -n`: Agent name
-- `--template, -t`: Template type
-- `--generate, -g`: Generate with AI
-
-## Development server
-
+## Run locally
+```bash
+nomos run --config config.agent.yaml --port 8000
 ```
-nomos run
-```
+Use `--watch` to reload on changes.
 
-Pass `--config` for a YAML file and `--port` to change the port.
-
-## Production
-
-```
-nomos serve --detach
+## Serve in production
+```bash
+nomos serve --config config.agent.yaml --detach
 ```
 
-See the README for full option lists.
+## Test an agent
+```bash
+nomos test -c tests.agent.yaml
+```

--- a/docs/developer/usage/deployment.md
+++ b/docs/developer/usage/deployment.md
@@ -1,19 +1,23 @@
 # Deployment
 
-Use the Docker base image `chandralegend/nomos-base` to containerize your agent.
+Package your agent in Docker using the `chandralegend/nomos-base` image.
 
-Example Dockerfile:
-
-```
+Example `Dockerfile`:
+```Dockerfile
 FROM chandralegend/nomos-base:latest
 COPY config.agent.yaml /app/config.agent.yaml
 COPY tools.py /app/src/tools/
+CMD ["nomos", "serve", "--config", "config.agent.yaml"]
 ```
 
-Runtime variables:
-
+Run it:
+```bash
+docker build -t my-agent .
+docker run -e OPENAI_API_KEY=sk-... my-agent
 ```
-| `OPENAI_API_KEY` | OpenAI API key |
-| `CONFIG_PATH` | Path to the agent config |
-| `ENABLE_TRACING` | Enable OpenTelemetry tracing |
+Key variables:
+```
+| `OPENAI_API_KEY` | API key for your model provider |
+| `CONFIG_PATH`    | Path to the agent config        |
+| `ENABLE_TRACING` | Enable OpenTelemetry tracing    |
 ```

--- a/docs/developer/usage/deployment.md
+++ b/docs/developer/usage/deployment.md
@@ -1,0 +1,19 @@
+# Deployment
+
+Use the Docker base image `chandralegend/nomos-base` to containerize your agent.
+
+Example Dockerfile:
+
+```
+FROM chandralegend/nomos-base:latest
+COPY config.agent.yaml /app/config.agent.yaml
+COPY tools.py /app/src/tools/
+```
+
+Runtime variables:
+
+```
+| `OPENAI_API_KEY` | OpenAI API key |
+| `CONFIG_PATH` | Path to the agent config |
+| `ENABLE_TRACING` | Enable OpenTelemetry tracing |
+```

--- a/docs/developer/usage/testing.md
+++ b/docs/developer/usage/testing.md
@@ -1,0 +1,15 @@
+# Testing
+
+Nomos offers utilities for evaluating agent interactions.
+
+## Smart Assertions
+
+```
+smart_assert(decision, "Agent should greet the user", agent.llm)
+```
+
+## Scenario Testing
+
+```
+ScenarioRunner.run(agent, Scenario(scenario="User asks for budgeting advice"))
+```

--- a/docs/developer/usage/testing.md
+++ b/docs/developer/usage/testing.md
@@ -1,15 +1,27 @@
 # Testing
 
-Nomos offers utilities for evaluating agent interactions.
+Nomos includes helpers for validating conversations.
 
 ## Smart Assertions
-
-```
+```python
+from nomos.testing import smart_assert
 smart_assert(decision, "Agent should greet the user", agent.llm)
 ```
 
 ## Scenario Testing
-
-```
+```python
+from nomos.testing.eval import ScenarioRunner, Scenario
 ScenarioRunner.run(agent, Scenario(scenario="User asks for budgeting advice"))
+```
+
+## YAML Test Files
+Define tests in `tests.agent.yaml` and run `nomos test`.
+```yaml
+llm:
+  provider: openai
+  model: gpt-4o-mini
+unit:
+  hello:
+    input: "hello"
+    expectation: "Greets the user"
 ```

--- a/docs/developer/vision-inspiration.md
+++ b/docs/developer/vision-inspiration.md
@@ -1,0 +1,17 @@
+# Vision & Inspiration
+
+Nomos aims to provide **structured guidance** for AI behavior. The project name comes from the Greek word for "law" or "custom" and emphasizes rule‑based flows.
+
+Key features include:
+
+- step based agent flows
+- persona driven prompts
+- extensible tool integration
+
+These features are highlighted in the main README:
+
+```
+- **Step-based agent flows**: Define agent behavior as a sequence of steps, each with its own tools and transitions.
+- **Persona-driven**: Easily set the agent's persona for consistent, branded responses.
+- **Tool integration**: Register Python functions as tools for the agent to call.
+```

--- a/docs/developer/vision-inspiration.md
+++ b/docs/developer/vision-inspiration.md
@@ -1,17 +1,12 @@
 # Vision & Inspiration
 
-Nomos aims to provide **structured guidance** for AI behavior. The project name comes from the Greek word for "law" or "custom" and emphasizes rule‑based flows.
+Nomos is about giving you **control and observability** over AI agents. Instead of one large prompt, you guide the model through clear steps with explicit tool access. The framework was inspired by our own need to tame prompt-based chaos and build reliable assistants for production use.
 
-Key features include:
+Key ideas:
 
-- step based agent flows
-- persona driven prompts
-- extensible tool integration
+- **Step-based agents** keep behavior predictable and easier to debug.
+- **Persona-driven prompts** let you maintain consistent tone and brand voice.
+- **Extensible tools** allow safe interaction with your code and third‑party services.
+- **Flow groups** organize complex conversations with their own memory and metadata.
 
-These features are highlighted in the main README:
-
-```
-- **Step-based agent flows**: Define agent behavior as a sequence of steps, each with its own tools and transitions.
-- **Persona-driven**: Easily set the agent's persona for consistent, branded responses.
-- **Tool integration**: Register Python functions as tools for the agent to call.
-```
+Nomos draws inspiration from projects like CrewAI and LangChain but focuses on shipping enterprise-ready agents with strong testing and deployment stories.

--- a/docs/developer/vision-inspiration.md
+++ b/docs/developer/vision-inspiration.md
@@ -2,6 +2,10 @@
 
 Nomos is about giving you **control and observability** over AI agents. Instead of one large prompt, you guide the model through clear steps with explicit tool access. The framework was inspired by our own need to tame prompt-based chaos and build reliable assistants for production use.
 
+## Prompt‑based vs Step‑based
+
+Traditional prompt-based agents rely on a single instruction block. This can lead to unpredictable behavior and is hard to debug or test. Nomos breaks the conversation into **steps** so you can enforce a structure, control tool access, and validate each decision. This approach emphasizes collaboration, reliability, and observability.
+
 Key ideas:
 
 - **Step-based agents** keep behavior predictable and easier to debug.


### PR DESCRIPTION
## Summary
- add developer documentation with overview, TLDR and ELI5
- document vision, agent design, collaboration and reliability
- provide CLI, deployment and testing usage notes
- note the roadmap

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68530f3259ac8332b3d842d5a7f626df