### PR TITLE
Add external tool type selection

### DIFF
--- a/tools/visual-builder/frontend/src/components/nodes/ToolNode.tsx
+++ b/tools/visual-builder/frontend/src/components/nodes/ToolNode.tsx
@@ -4,7 +4,7 @@ import { Button } from '../ui/button';
 import { Edit, Wrench, AlertTriangle, AlertCircle } from 'lucide-react';
 import { useFlowContext } from '../../context/FlowContext';
 import { validateToolNode } from '../../utils/validation';
-import type { ToolNodeData } from '../../types';
+import type { ToolNodeData, ToolType } from '../../types';
 
 export const ToolNode = memo((props: NodeProps) => {
   const { setEditingNode } = useFlowContext();
@@ -22,29 +22,66 @@ export const ToolNode = memo((props: NodeProps) => {
 
   const paramCount = data.parameters ? Object.keys(data.parameters).length : 0;
 
+  const colorMap: Record<ToolType | 'custom', any> = {
+    custom: {
+      container: 'bg-blue-50 border-blue-300 hover:border-blue-400',
+      selected: 'bg-blue-100 border-blue-500 ring-2 ring-blue-200',
+      header: 'bg-blue-100 border-blue-200',
+      text: 'text-blue-800',
+      icon: 'text-blue-600',
+    },
+    crewai: {
+      container: 'bg-purple-50 border-purple-300 hover:border-purple-400',
+      selected: 'bg-purple-100 border-purple-500 ring-2 ring-purple-200',
+      header: 'bg-purple-100 border-purple-200',
+      text: 'text-purple-800',
+      icon: 'text-purple-600',
+    },
+    langchain: {
+      container: 'bg-green-50 border-green-300 hover:border-green-400',
+      selected: 'bg-green-100 border-green-500 ring-2 ring-green-200',
+      header: 'bg-green-100 border-green-200',
+      text: 'text-green-800',
+      icon: 'text-green-600',
+    },
+    pkg: {
+      container: 'bg-teal-50 border-teal-300 hover:border-teal-400',
+      selected: 'bg-teal-100 border-teal-500 ring-2 ring-teal-200',
+      header: 'bg-teal-100 border-teal-200',
+      text: 'text-teal-800',
+      icon: 'text-teal-600',
+    },
+  };
+
+  const colors = colorMap[data.tool_type || 'custom'];
+
   return (
-    <div className={`border rounded shadow-sm w-[200px] hover:border-blue-400 transition-colors ${
-      isSelected
-        ? 'bg-blue-100 border-blue-500 ring-2 ring-blue-200'
-        : hasErrors
-        ? 'bg-red-50 border-red-300'
-        : hasWarnings
-        ? 'bg-yellow-50 border-yellow-300'
-        : 'bg-blue-50 border-blue-300'
-    }`}>
-      {/* Header */}
-      <div className={`px-3 py-2 border-b rounded-t flex items-center justify-between ${
+    <div
+      className={`border rounded shadow-sm w-[200px] transition-colors ${
         isSelected
-          ? 'bg-blue-200 border-blue-300'
+          ? colors.selected
           : hasErrors
-          ? 'bg-red-100 border-red-200'
+          ? 'bg-red-50 border-red-300'
           : hasWarnings
-          ? 'bg-yellow-100 border-yellow-200'
-          : 'bg-blue-100 border-blue-200'
-      }`}>
+          ? 'bg-yellow-50 border-yellow-300'
+          : colors.container
+      }`}
+    >
+      {/* Header */}
+      <div
+        className={`px-3 py-2 border-b rounded-t flex items-center justify-between ${
+          isSelected
+            ? colors.selected
+            : hasErrors
+            ? 'bg-red-100 border-red-200'
+            : hasWarnings
+            ? 'bg-yellow-100 border-yellow-200'
+            : colors.header
+        }`}
+      >
         <div className="flex items-center gap-2 min-w-0 flex-1">
-          <Wrench className="w-4 h-4 text-blue-600 flex-shrink-0" />
-          <span className="font-medium text-sm text-blue-800 truncate">{data.name}</span>
+          <Wrench className={`w-4 h-4 flex-shrink-0 ${colors.icon}`} />
+          <span className={`font-medium text-sm truncate ${colors.text}`}>{data.name}</span>
           {hasErrors && (
             <div title="Node has validation errors">
               <AlertCircle className="w-4 h-4 text-red-500 flex-shrink-0" />
@@ -64,15 +101,15 @@ export const ToolNode = memo((props: NodeProps) => {
       {/* Body */}
       <div className="p-3 space-y-2">
         {data.description && (
-          <div className="text-sm text-blue-700 line-clamp-2">
-            {data.description}
-          </div>
+          <div className={`text-sm ${colors.text} line-clamp-2`}>{data.description}</div>
+        )}
+
+        {data.tool_type && data.tool_type !== 'custom' && data.tool_identifier && (
+          <div className={`text-xs ${colors.text} break-all`}>@{data.tool_type}/{data.tool_identifier}</div>
         )}
 
         {paramCount > 0 && (
-          <div className="text-xs text-blue-600">
-            {paramCount} parameter{paramCount !== 1 ? 's' : ''}
-          </div>
+          <div className={`text-xs ${colors.text}`}>{paramCount} parameter{paramCount !== 1 ? 's' : ''}</div>
         )}
       </div>
 
@@ -81,7 +118,7 @@ export const ToolNode = memo((props: NodeProps) => {
         type="target"
         position={Position.Left}
         id="tool-input"
-        className="w-2 h-2 !bg-blue-500 border-2 border-white"
+        className={`w-2 h-2 border-2 border-white ${colors.icon}`}
       />
     </div>
   );

--- a/tools/visual-builder/frontend/src/components/panels/NodeEditPanel.tsx
+++ b/tools/visual-builder/frontend/src/components/panels/NodeEditPanel.tsx
@@ -132,16 +132,52 @@ export function NodeEditPanel({ node, onClose, onSave }: NodeEditPanelProps) {
                 />
               </div>
 
-              {/* Package Reference */}
+              {/* Tool Type */}
               <div className="space-y-2">
-                <Label htmlFor="package_reference">Package Reference</Label>
-                <Input
-                  id="package_reference"
-                  value={formData.package_reference || ''}
-                  onChange={(e) => updateField('package_reference', e.target.value)}
-                  placeholder="package_name:function_name (optional)"
-                />
+                <Label htmlFor="tool_type">Tool Type</Label>
+                <select
+                  id="tool_type"
+                  value={formData.tool_type || 'custom'}
+                  onChange={(e) => updateField('tool_type', e.target.value)}
+                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background"
+                >
+                  <option value="custom">Custom</option>
+                  <option value="crewai">CrewAI</option>
+                  <option value="langchain">Langchain</option>
+                  <option value="pkg">Package</option>
+                </select>
               </div>
+
+              {formData.tool_type && formData.tool_type !== 'custom' && (
+                <div className="space-y-2">
+                  <Label htmlFor="tool_identifier">Tool Identifier</Label>
+                  <Input
+                    id="tool_identifier"
+                    value={formData.tool_identifier || ''}
+                    onChange={(e) => updateField('tool_identifier', e.target.value)}
+                    placeholder="Class or function path"
+                  />
+                </div>
+              )}
+
+              {formData.tool_type && formData.tool_type !== 'custom' && (
+                <div className="space-y-2">
+                  <Label htmlFor="kwargs">Kwargs (JSON)</Label>
+                  <Textarea
+                    id="kwargs"
+                    value={JSON.stringify(formData.kwargs || {}, null, 2)}
+                    onChange={(e) => {
+                      try {
+                        updateField('kwargs', JSON.parse(e.target.value));
+                      } catch {
+                        /* ignore invalid JSON */
+                      }
+                    }}
+                    placeholder="{\"key\": \"value\"}"
+                    rows={3}
+                  />
+                </div>
+              )}
             </>
           )}
         </div>

--- a/tools/visual-builder/frontend/src/components/panels/NodeEditPanel.tsx
+++ b/tools/visual-builder/frontend/src/components/panels/NodeEditPanel.tsx
@@ -173,7 +173,7 @@ export function NodeEditPanel({ node, onClose, onSave }: NodeEditPanelProps) {
                         /* ignore invalid JSON */
                       }
                     }}
-                    placeholder="{\"key\": \"value\"}"
+                    placeholder='{"key": "value"}'
                     rows={3}
                   />
                 </div>

--- a/tools/visual-builder/frontend/src/models/nomos.ts
+++ b/tools/visual-builder/frontend/src/models/nomos.ts
@@ -17,6 +17,9 @@ export interface ToolConfig {
   description?: string;
   parameters?: Record<string, ToolParameter>;
   package_reference?: string;
+  tool_type?: 'custom' | 'crewai' | 'langchain' | 'pkg';
+  tool_identifier?: string;
+  kwargs?: Record<string, any>;
 }
 
 export interface ToolParameter {
@@ -54,7 +57,11 @@ export interface NomosConfig {
   start_step_id: string;
   steps: StepConfig[];
   flows?: FlowConfig[];
-  tools?: ToolConfig[];
+  tools?: {
+    tool_files?: string[];
+    external_tools?: Array<{ tag: string; name: string; kwargs?: Record<string, any> }>;
+    tool_arg_descriptions?: Record<string, Record<string, string>>;
+  };
   llm?: LLMConfig;
   max_iter?: number;
   max_errors?: number;

--- a/tools/visual-builder/frontend/src/types/index.ts
+++ b/tools/visual-builder/frontend/src/types/index.ts
@@ -10,11 +10,28 @@ export interface StepNodeData {
   [key: string]: unknown;
 }
 
+export type ToolType = 'custom' | 'crewai' | 'langchain' | 'pkg';
+
 export interface ToolNodeData {
   name: string;
   description?: string;
   parameters?: Record<string, { type: string; description?: string }>;
+  tool_type?: ToolType;
+  tool_identifier?: string;
+  kwargs?: Record<string, any>;
   [key: string]: unknown;
+}
+
+export interface ExternalTool {
+  tag: string;
+  name: string;
+  kwargs?: Record<string, any>;
+}
+
+export interface ToolsConfig {
+  tool_files?: string[];
+  external_tools?: ExternalTool[];
+  tool_arg_descriptions?: Record<string, Record<string, string>>;
 }
 
 export interface AgentConfig {
@@ -23,7 +40,7 @@ export interface AgentConfig {
   start_step_id: string;
   steps: StepConfig[];
   flows?: FlowConfig[];
-  tool_arg_descriptions?: Record<string, Record<string, string>>;
+  tools?: ToolsConfig;
   llm?: LLMConfig;
 }
 

--- a/tools/visual-builder/frontend/src/utils/validation.ts
+++ b/tools/visual-builder/frontend/src/utils/validation.ts
@@ -124,6 +124,16 @@ export function validateToolNode(data: ToolNodeData): ValidationResult {
     });
   }
 
+  if (data.tool_type && data.tool_type !== 'custom') {
+    if (!data.tool_identifier || data.tool_identifier.trim() === '') {
+      errors.push({
+        field: 'tool_identifier',
+        message: 'Tool identifier is required for external tools',
+        severity: 'error'
+      });
+    }
+  }
+
   return {
     isValid: errors.length === 0,
     errors,


### PR DESCRIPTION
## Summary
- add `tool_type` and `tool_identifier` fields for tool nodes
- color-code tool nodes by type
- disable editing of crewai/langchain descriptions
- export/import external tools using new fields