### PR TITLE
Expand developer docs

### DIFF
--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -6,7 +6,7 @@ overview and then dive into the workflow that matches your team.
 
 ## Choose Your Workflow
 
-- **[Fullcode](fullcode/README.md)** – write steps, tools and tests completely in
+- **[Full-code](full-code/README.md)** – write steps, tools and tests completely in
   Python.
 - **[Less-code](less-code/README.md)** – define agents in YAML while keeping
   tools and deeper tests in Python.

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -1,0 +1,26 @@
+# Nomos Developer Documentation
+
+Welcome to the Nomos developer docs. This section explains how to build and test
+your own step‑based agents using different levels of code. Start with a quick
+overview and then dive into the workflow that matches your team.
+
+## Choose Your Workflow
+
+- **[Fullcode](fullcode/README.md)** – write steps, tools and tests completely in
+  Python.
+- **[Less-code](less-code/README.md)** – define agents in YAML while keeping
+  tools and deeper tests in Python.
+- **[No-code](no-code/README.md)** – configure everything in YAML and reuse
+  package tools.
+
+## Additional Guides
+
+- [TLDR](tldr.md) – one minute summary.
+- [ELI5 Overview](eli5.md) – a kid‑friendly explanation.
+- [Vision & Inspiration](vision-inspiration.md)
+- [Agent Design](agent-design.md)
+- [Collaboration & Reliability](collaboration.md)
+- [Usage](usage/cli.md)
+  - [Deployment](usage/deployment.md)
+  - [Testing](usage/testing.md)
+- [Roadmap](roadmap.md)

--- a/docs/developer/agent-design.md
+++ b/docs/developer/agent-design.md
@@ -19,14 +19,6 @@ used. You may define routes to jump to another step when conditions are met.
       condition: Information complete
 ```
 
-### Visualising a Simple Flow
-
-```mermaid
-flowchart TD
-    start([Start]) --> gather[Gather Info]
-    gather -->|Information complete| finish([Finish])
-```
-
 ## Flows
 
 Flows group related steps and can carry dedicated memory components. When

--- a/docs/developer/agent-design.md
+++ b/docs/developer/agent-design.md
@@ -1,0 +1,42 @@
+# Agent Design
+
+Nomos encourages a **step-based** approach where each step defines its own
+purpose and allowed tools. Steps are organised into flows so you can manage
+conversation context and transitions explicitly.
+
+## Steps
+
+Every step has an ID, a description for the LLM and a list of tools that can be
+used. You may define routes to jump to another step when conditions are met.
+
+```yaml
+- step_id: gather_info
+  description: Collect user data
+  available_tools:
+    - ask_database
+  routes:
+    - target: finish
+      condition: Information complete
+```
+
+### Visualising a Simple Flow
+
+```mermaid
+flowchart TD
+    start([Start]) --> gather[Gather Info]
+    gather -->|Information complete| finish([Finish])
+```
+
+## Flows
+
+Flows group related steps and can carry dedicated memory components. When
+switching flows, Nomos summarises and transfers context automatically.
+
+Benefits of flows:
+
+1. **Scoped memory** – each flow keeps only relevant information.
+2. **Structured transitions** – define where a flow starts and ends.
+3. **Scalable design** – add new flows without changing existing ones.
+
+This structured design improves reliability and observability while letting you
+test each piece independently.

--- a/docs/developer/collaboration.md
+++ b/docs/developer/collaboration.md
@@ -1,0 +1,27 @@
+# Collaboration & Reliability
+
+Nomos is built with teamwork in mind. Sharing YAML config files makes reviewing
+changes simple and keeps everyone on the same page. The CLI can bootstrap new
+projects so each contributor starts from a common template.
+
+## Version Control Friendly
+
+- YAML configs can be tracked in Git or any VCS for clear history and code
+  reviews.
+- Multiple environments (dev, staging, prod) can share a base config with small
+  overrides.
+
+## Observability
+
+Enable tracing to collect detailed logs and spans:
+
+```
+| `ENABLE_TRACING`        | Enable OpenTelemetry tracing (`true`/`false`) |
+| `ELASTIC_APM_SERVER_URL`| Elastic APM server URL                      |
+```
+
+## Continuous Testing
+
+When an error occurs the agent retries and logs useful details. Combine
+`ScenarioRunner` and `smart_assert` in your CI pipeline to automatically validate
+conversations across updates.

--- a/docs/developer/eli5.md
+++ b/docs/developer/eli5.md
@@ -1,0 +1,6 @@
+# ELI5
+
+Imagine Nomos as a friendly robot you can program with simple instructions.
+Instead of giving it one long paragraph, you tell it **step by step** what to do
+and which gadgets it can use. Because it follows your steps one by one, the
+robot behaves the way you expect and keeps track of everything you say.

--- a/docs/developer/full-code/README.md
+++ b/docs/developer/full-code/README.md
@@ -1,4 +1,4 @@
-# Fullcode Development
+# Full-code Development
 
 Write every part of your agent in Python for maximum flexibility. Use this mode
 when you want tight control over logic, tools and tests.
@@ -28,12 +28,4 @@ agent = Nomos(name="clock", llm=None, steps=steps, tools=[get_time], start_step_
 def test_start():
     decision, *_ = agent.next("time?", {})
     smart_assert(decision, "Agent tells the time", agent.llm)
-```
-
-### Mermaid Overview
-
-```mermaid
-flowchart LR
-    start([start]) --> tool[get_time]
-    tool --> end([finish])
 ```

--- a/docs/developer/fullcode/README.md
+++ b/docs/developer/fullcode/README.md
@@ -1,0 +1,39 @@
+# Fullcode Development
+
+Write every part of your agent in Python for maximum flexibility. Use this mode
+when you want tight control over logic, tools and tests.
+
+## Structure
+
+- **Steps and flows** are created with the `Step` and `FlowConfig` classes.
+- **Tools** are regular Python functions that you register with the agent.
+- **Tests** use the `smart_assert` helpers directly in Python.
+
+## Example
+
+```python
+from nomos import Nomos, Step
+from nomos.testing import smart_assert
+
+def get_time() -> str:
+    from datetime import datetime
+    return str(datetime.utcnow())
+
+steps = [
+    Step(step_id="start", description="Tell the time", available_tools=["get_time"])
+]
+
+agent = Nomos(name="clock", llm=None, steps=steps, tools=[get_time], start_step_id="start")
+
+def test_start():
+    decision, *_ = agent.next("time?", {})
+    smart_assert(decision, "Agent tells the time", agent.llm)
+```
+
+### Mermaid Overview
+
+```mermaid
+flowchart LR
+    start([start]) --> tool[get_time]
+    tool --> end([finish])
+```

--- a/docs/developer/less-code/README.md
+++ b/docs/developer/less-code/README.md
@@ -6,6 +6,7 @@ extensive tests.
 ## 1. Agent YAML
 
 ```yaml
+# config.agent.yaml
 name: math-bot
 persona: Answers math questions
 steps:
@@ -14,20 +15,30 @@ steps:
     available_tools:
       - sqrt
 start_step_id: start
+
+tools:
+  tool_files:
+    - tools.py
 ```
 
 ## 2. Tool Module
 
 ```python
+# tools.py
 from math import sqrt
 
 def sqrt_tool(x: float) -> float:
     return sqrt(x)
+
+tools = [
+    sqrt_tool
+]
 ```
 
 ## 3. Test Config
 
 ```yaml
+# tests.agent.yaml
 llm:
   provider: openai
   model: gpt-4o-mini
@@ -37,12 +48,7 @@ unit:
     expectation: "Returns 2"
 ```
 
-### Diagram
-
-```mermaid
-flowchart LR
-    start([start]) --> tool[sqrt]
-```
 
 Run the agent with `nomos run --config config.agent.yaml` and run tests using
 `nomos test -c tests.agent.yaml`.
+Tests can be ran using `nomos test -c tests.agent.yaml`.

--- a/docs/developer/less-code/README.md
+++ b/docs/developer/less-code/README.md
@@ -1,0 +1,48 @@
+# Less-code Development
+
+Use YAML to describe your agent while keeping Python for custom tools and
+extensive tests.
+
+## 1. Agent YAML
+
+```yaml
+name: math-bot
+persona: Answers math questions
+steps:
+  - step_id: start
+    description: Respond to calculations
+    available_tools:
+      - sqrt
+start_step_id: start
+```
+
+## 2. Tool Module
+
+```python
+from math import sqrt
+
+def sqrt_tool(x: float) -> float:
+    return sqrt(x)
+```
+
+## 3. Test Config
+
+```yaml
+llm:
+  provider: openai
+  model: gpt-4o-mini
+unit:
+  sqrt:
+    input: "sqrt 4"
+    expectation: "Returns 2"
+```
+
+### Diagram
+
+```mermaid
+flowchart LR
+    start([start]) --> tool[sqrt]
+```
+
+Run the agent with `nomos run --config config.agent.yaml` and run tests using
+`nomos test -c tests.agent.yaml`.

--- a/docs/developer/no-code/README.md
+++ b/docs/developer/no-code/README.md
@@ -1,0 +1,25 @@
+# No-code Development
+
+Configure everything in YAML and reuse ready‑made tools. Great for quick
+prototypes or non‑developers.
+
+## Visual Flow Builder
+
+Use the hosted builder at [nomos.dowhile.dev/try](https://nomos.dowhile.dev/try)
+to design your flows without writing code. Export the YAML and run it with the
+CLI.
+
+## Example Config
+
+```yaml
+name: support-bot
+persona: Helpful assistant
+steps:
+  - step_id: start
+    description: Answer FAQs
+    available_tools:
+      - crewai.search_web
+start_step_id: start
+```
+
+Run with `nomos serve --config config.agent.yaml`.

--- a/docs/developer/no-code/README.md
+++ b/docs/developer/no-code/README.md
@@ -12,14 +12,20 @@ CLI.
 ## Example Config
 
 ```yaml
+# config.agent.yaml
 name: support-bot
 persona: Helpful assistant
 steps:
   - step_id: start
     description: Answer FAQs
     available_tools:
-      - crewai.search_web
+      - search_web
 start_step_id: start
+
+tools:
+  external_tools:
+    - tag: crewai/SerperDevTool
+      name: search_web
 ```
 
-Run with `nomos serve --config config.agent.yaml`.
+Run with `nomos run --config config.agent.yaml`.

--- a/docs/developer/roadmap.md
+++ b/docs/developer/roadmap.md
@@ -1,0 +1,13 @@
+# Roadmap
+
+Nomos is evolving quickly. Planned areas of improvement include:
+
+- Richer visual builder and improved CLI scaffolding.
+- More built-in tools and tighter integration with CrewAI packages.
+- Advanced tracing adapters for popular observability platforms.
+- Expanded YAML schema validation and helpful error messages.
+- Built-in analytics dashboard for monitoring agent performance.
+- Simplified deployment templates for common cloud providers.
+
+Follow [open issues](https://github.com/dowhiledev/nomos/issues?q=label%3Aenhancement+is%3Aopen+sort%3Areactions-%2B1-desc)
+for the latest progress.

--- a/docs/developer/tldr.md
+++ b/docs/developer/tldr.md
@@ -1,0 +1,9 @@
+# TLDR
+
+A lightning-fast overview of why Nomos matters:
+
+- **Multi-step agents** – break tasks into predictable steps with explicit tool
+  access.
+- **Flexible workflows** – build in pure Python or use YAML for configuration.
+- **Production ready** – tracing, error handling and deep testing are built in.
+- **Portable** – run locally, in Docker or on your favourite cloud platform.

--- a/docs/developer/usage/cli.md
+++ b/docs/developer/usage/cli.md
@@ -1,0 +1,35 @@
+# CLI Quick Reference
+
+Nomos provides a single `nomos` command with several helpful sub‑commands.
+
+## init – create a project
+
+```bash
+nomos init --directory ./my-bot --name chatbot --template basic
+```
+
+Options:
+- `--directory, -d` project directory
+- `--name, -n` agent name
+- `--template, -t` template type
+- `--generate, -g` let Nomos draft your config
+
+## run – local development
+
+```bash
+nomos run --config config.agent.yaml --port 8000
+```
+
+Use `--watch` to reload on changes.
+
+## serve – production deployment
+
+```bash
+nomos serve --config config.agent.yaml --detach
+```
+
+## test – run unit and scenario tests
+
+```bash
+nomos test -c tests.agent.yaml
+```

--- a/docs/developer/usage/cli.md
+++ b/docs/developer/usage/cli.md
@@ -25,7 +25,7 @@ Use `--watch` to reload on changes.
 ## serve – production deployment
 
 ```bash
-nomos serve --config config.agent.yaml --detach
+nomos serve --config config.agent.yaml
 ```
 
 ## test – run unit and scenario tests

--- a/docs/developer/usage/deployment.md
+++ b/docs/developer/usage/deployment.md
@@ -1,0 +1,27 @@
+# Deployment
+
+Package your agent in Docker using the `chandralegend/nomos-base` image.
+
+## Dockerfile
+
+```Dockerfile
+FROM chandralegend/nomos-base:latest
+COPY config.agent.yaml /app/config.agent.yaml
+COPY tools.py /app/src/tools/
+CMD ["nomos", "serve", "--config", "config.agent.yaml"]
+```
+
+## Build and Run
+
+```bash
+docker build -t my-agent .
+docker run -e OPENAI_API_KEY=sk-... my-agent
+```
+
+## Key Variables
+
+```
+| `OPENAI_API_KEY` | API key for your model provider |
+| `CONFIG_PATH`    | Path to the agent config        |
+| `ENABLE_TRACING` | Enable OpenTelemetry tracing    |
+```

--- a/docs/developer/usage/testing.md
+++ b/docs/developer/usage/testing.md
@@ -28,4 +28,9 @@ unit:
   hello:
     input: "hello"
     expectation: "Greets the user"
+
+e2e:
+  budgeting:
+    scenario: "User asks for budgeting advice"
+    expectation: "Provides a budget plan"
 ```

--- a/docs/developer/usage/testing.md
+++ b/docs/developer/usage/testing.md
@@ -1,0 +1,31 @@
+# Testing
+
+Nomos includes helpers for validating conversations.
+
+## Smart Assertions
+
+```python
+from nomos.testing import smart_assert
+smart_assert(decision, "Agent should greet the user", agent.llm)
+```
+
+## Scenario Testing
+
+```python
+from nomos.testing.eval import ScenarioRunner, Scenario
+ScenarioRunner.run(agent, Scenario(scenario="User asks for budgeting advice"))
+```
+
+## YAML Test Files
+
+Define tests in `tests.agent.yaml` and run `nomos test`.
+
+```yaml
+llm:
+  provider: openai
+  model: gpt-4o-mini
+unit:
+  hello:
+    input: "hello"
+    expectation: "Greets the user"
+```

--- a/docs/developer/vision-inspiration.md
+++ b/docs/developer/vision-inspiration.md
@@ -1,0 +1,27 @@
+# Vision & Inspiration
+
+Nomos exists so developers can build AI agents that do **exactly** what they are
+told. Instead of a single giant prompt, Nomos lets you guide the model through a
+sequence of well defined steps. This structure gives you visibility into every
+decision and makes it easy to test and debug.
+
+## Prompt‑Based vs Step‑Based
+
+Prompt‑based agents often combine instructions, examples and constraints into one
+block of text. They work for quick prototypes but quickly become hard to control
+or observe. A small change in wording can lead to unexpected behavior.
+
+Nomos introduces **step-based agents**. Each step has a clear purpose, a set of
+tools it may call and rules for moving to the next step. This approach emphasises
+**collaboration**, **reliability** and **observability**.
+
+### Key Concepts
+
+- **Step-based control** – predictable behavior that is easier to test.
+- **Persona driven prompts** – maintain consistent tone and brand voice.
+- **Extensible tools** – safely interact with your code or third‑party services.
+- **Flow groups** – organize complex conversations with memory and metadata.
+
+Nomos draws inspiration from open-source projects such as CrewAI and LangChain
+but focuses on shipping enterprise-ready agents with strong testing and
+deployment stories.


### PR DESCRIPTION
## Summary
- reorganize the developer README with clear workflow choices
- detail step-based agent design with Mermaid diagrams
- expand fullcode/less-code/no-code guides
- add collaboration tips and roadmap updates
- document CLI, deployment and testing usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68530f3259ac8332b3d842d5a7f626df