### PR TITLE
Improve auto arrange

### DIFF
--- a/support/visual-builder/frontend/.env.example
+++ b/support/visual-builder/frontend/.env.example
@@ -4,5 +4,5 @@
 # Backend API URL (where the FastAPI server runs)
 VITE_BACKEND_URL=http://localhost:8000
 
-# Nomos server URL (where the Nomos agent server runs)
-REACT_APP_NOMOS_SERVER_URL=http://localhost:8003
+# Set to 'true' to disable file upload functionality in the chat interface
+VITE_DISABLE_FILE_UPLOAD=false

--- a/support/visual-builder/frontend/src/utils/autoArrange.ts
+++ b/support/visual-builder/frontend/src/utils/autoArrange.ts
@@ -1,6 +1,15 @@
 import dagre from 'dagre';
 import type { Node, Edge } from '@xyflow/react';
 
+// Extended Node type that includes style property
+type NodeWithStyle = Node & {
+  style?: {
+    width?: number;
+    height?: number;
+    [key: string]: any;
+  };
+};
+
 // Fixed node dimensions
 const STEP_NODE_WIDTH = 280;
 const STEP_NODE_HEIGHT = 140;
@@ -261,7 +270,7 @@ export function autoArrangeNodes(nodes: Node[], edges: Edge[]): Node[] {
   const COMPONENT_SPACING = 200;
   let currentOffsetX = 0;
 
-  components.forEach((comp, idx) => {
+  components.forEach((comp) => {
     let minX = Infinity;
     let maxX = -Infinity;
     comp.forEach(id => {
@@ -271,8 +280,8 @@ export function autoArrangeNodes(nodes: Node[], edges: Edge[]): Node[] {
       if (!node) {
         node = optimizedGroupNodes.find(n => n.id === id);
         if (node) {
-          width = (node.style?.width as number) || 400;
-          height = (node.style?.height as number) || 300;
+          width = ((node as NodeWithStyle).style?.width as number) || 400;
+          height = ((node as NodeWithStyle).style?.height as number) || 300;
         }
       }
       if (node) {


### PR DESCRIPTION
This pull request introduces two main sets of changes: enhancements to the `ChatPopup` component to allow conditional disabling of file uploads and significant improvements to the `autoArrangeNodes` utility for better node positioning in the visual builder. Below is a breakdown of the most important changes:

### ChatPopup Enhancements:
* Added a new environment variable `VITE_DISABLE_FILE_UPLOAD` to control whether file uploads are enabled in the chat interface. This is configured in `.env.example` and accessed in `ChatPopup.tsx` (`support/visual-builder/frontend/.env.example`, `support/visual-builder/frontend/src/components/ChatPopup.tsx`) [[1]](diffhunk://#diff-0f8a89c85322cccf9f2373b62b0cf5696b73fab69be709647212f880e444b21fL7-R8) [[2]](diffhunk://#diff-2f8cf3ff6d8d2ff9a8b4e5eaf8d6276c33d2121de0b47a97e8ef6affaf9ec411R48).
* Updated `uploadTools` and `saveAndStart` methods in `ChatPopup` to respect the `DISABLE_FILE_UPLOAD` flag, preventing file uploads when the flag is set to `true` [[1]](diffhunk://#diff-2f8cf3ff6d8d2ff9a8b4e5eaf8d6276c33d2121de0b47a97e8ef6affaf9ec411R177-R181) [[2]](diffhunk://#diff-2f8cf3ff6d8d2ff9a8b4e5eaf8d6276c33d2121de0b47a97e8ef6affaf9ec411L198-R204).
* Conditionally rendered the file upload UI elements based on the `DISABLE_FILE_UPLOAD` flag to hide them when uploads are disabled [[1]](diffhunk://#diff-2f8cf3ff6d8d2ff9a8b4e5eaf8d6276c33d2121de0b47a97e8ef6affaf9ec411R509-R510) [[2]](diffhunk://#diff-2f8cf3ff6d8d2ff9a8b4e5eaf8d6276c33d2121de0b47a97e8ef6affaf9ec411R536-R537).

### Auto-Arrange Node Improvements:
* Introduced a new `arrangeStepsInGroup` function to arrange step nodes within a group using a `dagre` layout algorithm, improving the organization of grouped nodes (`support/visual-builder/frontend/src/utils/autoArrange.ts`).
* Enhanced the `autoArrangeNodes` function to handle multiple disconnected flows by separating components and applying spacing between them, ensuring better visual clarity [[1]](diffhunk://#diff-359cb37b6d63e103617e62b5e4df21d1a7f6f69cba42a032f7e9e749a255eb3cR190-R198) [[2]](diffhunk://#diff-359cb37b6d63e103617e62b5e4df21d1a7f6f69cba42a032f7e9e749a255eb3cR222-R325).
* Improved tool node positioning by associating tools with their connected steps and placing unconnected tools in fallback areas, while avoiding overlaps with steps, groups, and other tools [[1]](diffhunk://#diff-359cb37b6d63e103617e62b5e4df21d1a7f6f69cba42a032f7e9e749a255eb3cL195-R476) [[2]](diffhunk://#diff-359cb37b6d63e103617e62b5e4df21d1a7f6f69cba42a032f7e9e749a255eb3cL358-R504) [[3]](diffhunk://#diff-359cb37b6d63e103617e62b5e4df21d1a7f6f69cba42a032f7e9e749a255eb3cL382-R519).
* Refactored tool positioning logic to use a more natural placement strategy, ensuring tools are located near their connected nodes while maintaining spacing [[1]](diffhunk://#diff-359cb37b6d63e103617e62b5e4df21d1a7f6f69cba42a032f7e9e749a255eb3cL195-R476) [[2]](diffhunk://#diff-359cb37b6d63e103617e62b5e4df21d1a7f6f69cba42a032f7e9e749a255eb3cL358-R504)