### PR TITLE
Improve CLI usability with version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ While NOMOS can be used standalone, it integrates with a growing ecosystem of to
 - **[Visual Flow Builder](https://nomos.dowhile.dev/try)** - Design and prototype agent flows with our drag-and-drop interface. Perfect for rapid iteration and collaboration between technical and non-technical team members.
 - **[TypeScript SDK](support/ts-sdk/README.md)** - Full-featured client library for web and Node.js applications, enabling seamless integration of NOMOS agents into your frontend applications.
 - **[Docker Base Images](docs/deployment.md#docker-base-image)** - Pre-configured containers for rapid deployment with built-in support for Redis, PostgreSQL, and monitoring integrations.
-- **[CLI Tools](docs/cli-usage.md)** - Comprehensive command-line interface for agent development, testing, and deployment with `nomos init`, `nomos run`, and `nomos serve` commands.
+- **[CLI Tools](docs/cli-usage.md)** - Comprehensive command-line interface for agent development, testing, and deployment with `nomos init`, `nomos run`, `nomos serve`, `nomos test`, and `nomos --version` commands.
 
 ## Key Features
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -8,6 +8,14 @@ The Nomos CLI provides powerful commands to bootstrap, develop, and deploy your 
 - [`nomos run`](#development-mode) - Run agent in development mode
 - [`nomos serve`](#production-deployment) - Deploy agent with Docker
 - [`nomos test`](#testing) - Run agent tests
+- `nomos --version` - Display CLI version
+
+### Check Version and Help
+
+```bash
+nomos --version
+nomos --help
+```
 
 ## Initialize a New Agent
 

--- a/nomos/cli.py
+++ b/nomos/cli.py
@@ -16,6 +16,7 @@ from rich.text import Text
 
 import typer
 
+from . import __version__
 from .config import AgentConfig
 from .llms import LLMConfig
 from .server import run_server
@@ -34,6 +35,27 @@ PRIMARY_COLOR = "cyan"
 SUCCESS_COLOR = "green"
 WARNING_COLOR = "yellow"
 ERROR_COLOR = "red"
+
+
+def _version_callback(value: bool) -> None:
+    """Show version and exit."""
+    if value:
+        console.print(__version__)
+        raise typer.Exit()
+
+
+@app.callback()
+def cli_app(
+    version: Optional[bool] = typer.Option(
+        None,
+        "--version",
+        help="Show Nomos version and exit",
+        callback=_version_callback,
+        is_eager=True,
+    ),
+) -> None:
+    """Nomos CLI."""
+    pass
 
 
 def print_banner() -> None:


### PR DESCRIPTION
## Summary
- add a `--version` option to the CLI
- document new flag in `docs/cli-usage.md`
- mention additional CLI commands in README

## Testing
- `python -m pip install -e .[cli]`
- `python -m pip install pytest pytest-cov`
- `python -m pip install crewai[tools] redis sqlmodel`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68575777c9148332b114f980a955cca9