### PR TITLE
Fix for Tools with No Types Defines Fails

### DIFF
--- a/cookbook/examples/barista/config.agent.yaml
+++ b/cookbook/examples/barista/config.agent.yaml
@@ -101,17 +101,25 @@ flows:
 tools:
   tool_files:
     - barista_tools.py
-  tool_arg_descriptions:
+  tool_defs:
     add_to_cart:
-      coffee_type: Coffee type (e.g., Espresso, Latte, Cappuccino)
-      size: Size of the coffee (Small, Medium, Large)
-      price: Price of the coffee
+      args:
+        - key: coffee_type
+          desc: "Type of coffee (e.g., Espresso, Latte, Cappuccino)"
+        - key: size
+          desc: "Size of the coffee (Small, Medium, Large)"
+        - key: price
+          desc: "Price of the coffee"
     remove_item:
-      item_id: The ID of the item to remove from the cart
+      args:
+        - key: item_id
+          desc: "The ID of the item to remove from the cart"
     finalize_order:
-      payment_method: Payment method (Card or Cash)
-      payment: Payment amount (required if payment_method is Cash)
-
+      args:
+        - key: payment_method
+          desc: "Payment method (Card or Cash)"
+        - key: payment
+          desc: "Payment amount (required if payment_method is Cash)"
 
 # llm configuration
 llm:

--- a/cookbook/examples/financial-advisor/config.agent.yaml
+++ b/cookbook/examples/financial-advisor/config.agent.yaml
@@ -103,18 +103,29 @@ steps:
 tools:
   tool_files:
     - tools.py
-  tool_arg_descriptions:
+  tool_defs:
     calculate_budget:
-      monthly_income: User's monthly income amount
+      args:
+        - key: monthly_income
+          desc: "User's monthly income amount"
     add_expense:
-      amount: Expense amount
-      category: One of Housing, Transportation, Food, Utilities, Entertainment, Savings
-      description: Brief description of the expense
-      date: Optional date in YYYY-MM-DD format
+      args:
+        - key: amount
+          desc: "Expense amount"
+        - key: category
+          desc: "One of Housing, Transportation, Food, Utilities, Entertainment, Savings"
+        - key: description
+          desc: "Brief description of the expense"
+        - key: date
+          desc: "Optional date in YYYY-MM-DD format"
     set_savings_goal:
-      target_amount: Goal amount to save
-      target_date: Target date in YYYY-MM-DD format
-      description: Description of the savings goal
+      args:
+        - key: target_amount
+          desc: "Goal amount to save"
+        - key: target_date
+          desc: "Target date in YYYY-MM-DD format"
+        - key: description
+          desc: "Description of the savings goal"
 
 llm:
   provider: openai

--- a/nomos/config.py
+++ b/nomos/config.py
@@ -14,7 +14,7 @@ from .llms import LLMBase, LLMConfig, OpenAI
 from .memory import MemoryConfig
 from .models.agent import Step
 from .models.flow import FlowConfig
-from .models.tool import ToolWrapper
+from .models.tool import ToolDef, ToolWrapper
 from .utils.utils import convert_camelcase_to_snakecase
 
 
@@ -68,7 +68,7 @@ class ToolsConfig(BaseModel):
 
     tool_files: List[str] = []  # List of tool files to load
     external_tools: Optional[List[ExternalTool]] = None  # List of external tools
-    tool_arg_descriptions: Optional[Dict[str, Dict[str, str]]] = None
+    tool_defs: Optional[Dict[str, ToolDef]] = None
 
     def get_tools(self) -> List[Union[Callable, ToolWrapper]]:
         """

--- a/nomos/core.py
+++ b/nomos/core.py
@@ -95,12 +95,12 @@ class Session:
                 f"Flow manager initialized with {len(self.flow_manager.flows)} flows"
             )
 
-        tool_arg_descs = (
-            self.config.tools.tool_arg_descriptions
-            if self.config and self.config.tools.tool_arg_descriptions
-            else {}
+        tool_defs = (
+            self.config.tools.tool_defs
+            if self.config and self.config.tools.tool_defs
+            else None
         )
-        self.tools = get_tools(tools, tool_arg_descs)
+        self.tools = get_tools(tools, tool_defs)
         # Variable
         self.memory = memory
         self.memory.context = history or []

--- a/nomos/models/tool.py
+++ b/nomos/models/tool.py
@@ -1,13 +1,33 @@
-"""Tool abstractions and related logic for the SOFIA package."""
+"""Tool abstractions and related logic for the Nomos package."""
 
 import inspect
-from typing import Any, Callable, Dict, Literal, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Type, Union
 
 from docstring_parser import parse
 
 from pydantic import BaseModel, ValidationError
 
-from ..utils.utils import create_base_model
+from ..utils.utils import create_base_model, parse_type
+
+
+class ArgDef(BaseModel):
+    """Documentation for an argument of a tool."""
+
+    key: str  # Name of the argument
+    desc: Optional[str] = None  # Description of the argument
+    type: Optional[str] = (
+        None  # Type of the argument (e.g., "str", "int", "float", "bool", "List[str]", etc.)
+    )
+
+    def get_type(self) -> Optional[Type]:
+        return parse_type(self.type) if self.type else None
+
+
+class ToolDef(BaseModel):
+    """Documentation for a tool."""
+
+    desc: Optional[str] = None  # Description of the tool
+    args: Optional[List[ArgDef]] = None  # Argument descriptions for the tool
 
 
 class Tool(BaseModel):
@@ -40,7 +60,7 @@ class Tool(BaseModel):
     def from_function(
         cls,
         function: Callable,
-        tool_arg_descs: Optional[Dict[str, Dict[str, str]]] = None,
+        tool_defs: Optional[Dict[str, ToolDef]] = None,
         name: Optional[str] = None,
     ) -> "Tool":
         """
@@ -51,42 +71,52 @@ class Tool(BaseModel):
         :return: An instance of Tool.
         """
         sig = inspect.signature(function)
+        name = name or function.__name__
         description = (
             parse(function.__doc__.strip()).short_description
             if function.__doc__
             else None
-        )
-        description = description or ""
+        ) or ""
 
-        tool_arg_desc_doc_params = (
-            parse(function.__doc__.strip()).params if function.__doc__ else []
-        )
-        tool_arg_desc_doc = {
-            param.arg_name: param.description
-            for param in tool_arg_desc_doc_params
-            if param.description
+        _doc_params = parse(function.__doc__.strip()).params if function.__doc__ else []
+        tool_arg_defs = {
+            param.arg_name: {
+                "description": param.description,
+                "type": param.type_name,
+            }
+            for param in _doc_params
         }
-        if tool_arg_descs is None:
-            tool_arg_descs = {}
-        tool_arg_desc = tool_arg_descs.get(function.__name__, {})
-        tool_arg_desc_doc.update(tool_arg_desc)
-        tool_arg_desc = tool_arg_desc_doc.copy()
+        if tool_defs is not None and name in tool_defs:
+            tool_def = tool_defs[name]
+            description = tool_def.desc or description
+            for arg in tool_def.args or []:
+                tool_arg_defs[arg.key] = {
+                    "description": arg.desc
+                    or tool_arg_defs.get(arg.key, {}).get("description"),
+                    "type": arg.type or tool_arg_defs.get(arg.key, {}).get("type"),
+                }
+
         params = {}
         for _name, param in sig.parameters.items():
-            param_info = {
-                "type": (
-                    param.annotation
-                    if param.annotation is not inspect.Parameter.empty
-                    else Any
-                )
+            _type = (
+                param.annotation
+                if param.annotation is not inspect.Parameter.empty
+                else tool_arg_defs.get(_name, {}).get("type")
+            )
+            _description = tool_arg_defs.get(_name, {}).get("description")
+            assert _type is not None, (
+                f"Type for parameter '{_name}' cannot be None. Please provide a valid type using "
+                "`tool.tool_defs`, add a type annotation to the function or write a docstring for the function."
+            )
+            params[_name] = {
+                "type": _type,
             }
-            if tool_arg_desc.get(_name):
-                param_info["description"] = tool_arg_desc[_name]
+            if _description:
+                params[_name]["description"] = _description
             if param.default is not inspect.Parameter.empty:
-                param_info["default"] = param.default
-            params[_name] = param_info
+                params[_name]["default"] = param.default
         return cls(
-            name=name or function.__name__,
+            name=name,
             description=description,
             function=function,
             parameters=params,
@@ -97,14 +127,13 @@ class Tool(BaseModel):
         cls,
         name: str,
         identifier: str,
-        tool_arg_descs: Optional[Dict[str, Dict[str, str]]] = None,
+        tool_defs: Optional[Dict[str, ToolDef]] = None,
     ) -> "Tool":
         """
         Create a Tool instance from a package identifier.
 
         :param identifier: The package identifier in the format "itertools.combinations", "package.submodule.submodule.function", etc.
         """
-        tool_arg_descs = tool_arg_descs or {}
         if "." not in identifier:
             raise ValueError(
                 f"Invalid tool identifier: {identifier}. It should be in the format 'package.submodule.function'."
@@ -119,7 +148,7 @@ class Tool(BaseModel):
             assert callable(
                 function
             ), f"'{function_name}' in module '{module_name}' is not callable."
-            return cls.from_function(function, tool_arg_descs, name)
+            return cls.from_function(function, tool_defs, name)
         except Exception as e:
             raise ValueError(f"Could not load tool {identifier}: {e}")
 
@@ -272,9 +301,7 @@ class ToolWrapper(BaseModel):
     name: str
     kwargs: Optional[dict] = None
 
-    def get_tool(
-        self, tool_arg_descs: Optional[Dict[str, Dict[str, str]]] = None
-    ) -> Tool:
+    def get_tool(self, tool_defs: Optional[Dict[str, ToolDef]] = None) -> Tool:
         """
         Get a Tool instance from the tool identifier.
 
@@ -284,7 +311,7 @@ class ToolWrapper(BaseModel):
             return Tool.from_pkg(
                 name=self.name,
                 identifier=self.tool_identifier,
-                tool_arg_descs=tool_arg_descs,
+                tool_defs=tool_defs,
             )
         if self.tool_type == "crewai":
             return Tool.from_crewai_tool(
@@ -300,22 +327,22 @@ class ToolWrapper(BaseModel):
 
 
 def get_tools(
-    tools: Optional[list[Union[Callable, ToolWrapper]]], tool_arg_desc: dict
+    tools: Optional[list[Union[Callable, ToolWrapper]]], tool_defs: Optional[Dict[str, ToolDef]] = None
 ) -> dict[str, Tool]:
     """
     Get a list of Tool instances from a list of functions or tool identifiers.
 
     :param tools: A list of functions or tool identifiers.
-    :param tool_arg_desc: A dictionary mapping function names to argument descriptions.
+    :param tool_defs: Optional dictionary of tool definitions for argument descriptions.
     :return: A dictionary mapping tool names to Tool instances.
     """
     _tools: dict[str, Tool] = {}
     for tool in tools or []:
         _tool = None
         if callable(tool):
-            _tool = Tool.from_function(tool, tool_arg_desc)
+            _tool = Tool.from_function(tool, tool_defs)
         if isinstance(tool, ToolWrapper):
-            _tool = tool.get_tool(tool_arg_desc)
+            _tool = tool.get_tool(tool_defs)
         assert _tool is not None, "Tool must be a callable or a ToolWrapper instance"
         _tools[_tool.name] = _tool
     return _tools

--- a/nomos/models/tool.py
+++ b/nomos/models/tool.py
@@ -27,7 +27,7 @@ class ToolDef(BaseModel):
     """Documentation for a tool."""
 
     desc: Optional[str] = None  # Description of the tool
-    args: Optional[List[ArgDef]] = None  # Argument descriptions for the tool
+    args: List[ArgDef]  # Argument descriptions for the tool
 
 
 class Tool(BaseModel):
@@ -108,6 +108,7 @@ class Tool(BaseModel):
                 f"Type for parameter '{_name}' cannot be None. Please provide a valid type using "
                 "`tool.tool_defs`, add a type annotation to the function or write a docstring for the function."
             )
+            _type = parse_type(_type) if isinstance(_type, str) else _type
             params[_name] = {
                 "type": _type,
             }
@@ -115,6 +116,7 @@ class Tool(BaseModel):
                 params[_name]["description"] = _description
             if param.default is not inspect.Parameter.empty:
                 params[_name]["default"] = param.default
+
         return cls(
             name=name,
             description=description,
@@ -327,7 +329,8 @@ class ToolWrapper(BaseModel):
 
 
 def get_tools(
-    tools: Optional[list[Union[Callable, ToolWrapper]]], tool_defs: Optional[Dict[str, ToolDef]] = None
+    tools: Optional[list[Union[Callable, ToolWrapper]]],
+    tool_defs: Optional[Dict[str, ToolDef]] = None,
 ) -> dict[str, Tool]:
     """
     Get a list of Tool instances from a list of functions or tool identifiers.

--- a/nomos/utils/utils.py
+++ b/nomos/utils/utils.py
@@ -1,7 +1,8 @@
 """Utility functions and helpers for the SOFIA package."""
 
+import ast
 from enum import Enum
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type, Union
 
 from pydantic import BaseModel, ConfigDict, Field, create_model
 
@@ -73,8 +74,46 @@ def convert_camelcase_to_snakecase(name: str) -> str:
     return "".join(["_" + i.lower() if i.isupper() else i for i in name]).lstrip("_")
 
 
+def parse_type(type_str: str) -> type:
+    """Safely parse type strings without eval/exec."""
+    # Type mapping
+    TYPE_MAP = {
+        "str": str,
+        "bool": bool,
+        "int": int,
+        "float": float,
+        "Dict": Dict,
+        "List": List,
+        "Tuple": Tuple,
+        "Union": Union,
+        "Literal": Literal,
+    }
+
+    def parse_expression(node) -> Any:  # noqa
+        if isinstance(node, ast.Name):
+            return TYPE_MAP.get(node.id, getattr(__builtins__, node.id, None))
+        elif isinstance(node, ast.Subscript):
+            base = parse_expression(node.value)
+            if isinstance(node.slice, ast.Tuple):
+                args = tuple(parse_expression(elt) for elt in node.slice.elts)
+            else:
+                args = (parse_expression(node.slice),)
+            return base[args] if len(args) > 1 else base[args[0]]
+        elif isinstance(node, ast.Constant):
+            return node.value
+        else:
+            raise ValueError(f"Unsupported node type: {type(node)}")
+
+    try:
+        tree = ast.parse(type_str, mode="eval")
+        return parse_expression(tree.body)
+    except Exception as e:
+        raise ValueError(f"Invalid type: {type_str}") from e
+
+
 __all__ = [
     "create_base_model",
     "create_enum",
     "convert_camelcase_to_snakecase",
+    "parse_type",
 ]

--- a/support/schemas/.nomos.json
+++ b/support/schemas/.nomos.json
@@ -1,5 +1,43 @@
 {
   "$defs": {
+    "ArgDef": {
+      "description": "Documentation for an argument of a tool.",
+      "properties": {
+        "key": {
+          "title": "Key",
+          "type": "string"
+        },
+        "desc": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Desc"
+        },
+        "type": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Type"
+        }
+      },
+      "required": [
+        "key"
+      ],
+      "title": "ArgDef",
+      "type": "object"
+    },
     "BaseModel": {
       "properties": {},
       "title": "BaseModel",
@@ -362,6 +400,35 @@
       "title": "Step",
       "type": "object"
     },
+    "ToolDef": {
+      "description": "Documentation for a tool.",
+      "properties": {
+        "desc": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Desc"
+        },
+        "args": {
+          "items": {
+            "$ref": "#/$defs/ArgDef"
+          },
+          "title": "Args",
+          "type": "array"
+        }
+      },
+      "required": [
+        "args"
+      ],
+      "title": "ToolDef",
+      "type": "object"
+    },
     "ToolsConfig": {
       "description": "Configuration for tools used by the agent.",
       "properties": {
@@ -388,14 +455,11 @@
           "default": null,
           "title": "External Tools"
         },
-        "tool_arg_descriptions": {
+        "tool_defs": {
           "anyOf": [
             {
               "additionalProperties": {
-                "additionalProperties": {
-                  "type": "string"
-                },
-                "type": "object"
+                "$ref": "#/$defs/ToolDef"
               },
               "type": "object"
             },
@@ -404,7 +468,7 @@
             }
           ],
           "default": null,
-          "title": "Tool Arg Descriptions"
+          "title": "Tool Defs"
         }
       },
       "title": "ToolsConfig",
@@ -520,7 +584,7 @@
       "default": {
         "tool_files": [],
         "external_tools": null,
-        "tool_arg_descriptions": null
+        "tool_defs": null
       }
     },
     "logging": {


### PR DESCRIPTION
This pull request introduces a major refactor of the tool configuration system in the Nomos package, replacing the previous `tool_arg_descriptions` structure with a more robust `tool_defs` system. This change enhances the flexibility and clarity of tool definitions, allowing for better handling of argument types and descriptions. Additionally, new utility functions and schema updates have been added to support these changes, alongside updates to testing fixtures.

### Tool Configuration Refactor:
* **`nomos/config.py`:** Replaced `tool_arg_descriptions` with `tool_defs` in `ToolsConfig` to support detailed argument definitions using the new `ToolDef` and `ArgDef` models.
* **`nomos/models/tool.py`:** Introduced `ToolDef` and `ArgDef` classes to encapsulate tool and argument metadata, including types and descriptions. Updated methods like `from_function`, `from_pkg`, and `get_tool` to utilize `tool_defs`. [[1]](diffhunk://#diff-2e8fb0da864c31e19576026ad82f5635aeec965d7701b071bca719e46664722eL1-R30) [[2]](diffhunk://#diff-2e8fb0da864c31e19576026ad82f5635aeec965d7701b071bca719e46664722eL43-R63) [[3]](diffhunk://#diff-2e8fb0da864c31e19576026ad82f5635aeec965d7701b071bca719e46664722eL100-L107) [[4]](diffhunk://#diff-2e8fb0da864c31e19576026ad82f5635aeec965d7701b071bca719e46664722eL275-R306)

### Utility Enhancements:
* **`nomos/utils/utils.py`:** Added `parse_type` function to safely parse type strings into Python types, supporting the new `ArgDef` model.

### Schema Updates:
* **`support/schemas/.nomos.json`:** Updated schema definitions to include `ToolDef` and `ArgDef`, aligning with the new tool configuration structure. [[1]](diffhunk://#diff-40a18c6180d6e0ffc1e0eb79fc5a57120554820fc8d13e9d59cd36a190afb381R3-R40) [[2]](diffhunk://#diff-40a18c6180d6e0ffc1e0eb79fc5a57120554820fc8d13e9d59cd36a190afb381R403-R431) [[3]](diffhunk://#diff-40a18c6180d6e0ffc1e0eb79fc5a57120554820fc8d13e9d59cd36a190afb381L391-R462)

### Testing Updates:
* **`tests/conftest.py`:** Added a `tool_defs` fixture to test the new tool definition system. Updated `basic_agent` fixture to use `tool_defs` in `ToolsConfig`.
* **`tests/test_core.py`:** Modified tests to accommodate the updated tool configuration system.

These changes collectively improve the modularity, readability, and extensibility of the tool configuration system, paving the way for more sophisticated tool integrations in the Nomos package.