### PR TITLE
Add step examples feature docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ While NOMOS can be used standalone, it integrates with a growing ecosystem of to
 | **LLM Support** | Multiple Providers | OpenAI, Mistral, Gemini, Ollama, and HuggingFace |
 | | Structured Responses | Step-level answer models for JSON/object responses |
 | | Persona-driven | Consistent, branded agent responses |
+| | Decision Examples | Retrieve relevant examples to guide step decisions |
 | **Production Ready** | Session Management | Redis/PostgreSQL storage for conversation persistence |
 | | Error Handling | Built-in recovery with configurable retry limits |
 | | API Integration | FastAPI endpoints for web and WebSocket interaction |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,6 +201,28 @@ tools:
 nomos run --config config.agent.yaml --tools tools/my_tools.py
 ```
 
+## Step Examples
+
+You can provide decision examples for any step. Each example contains the user
+context and the expected decision. NOMOS retrieves relevant examples using
+embeddings and includes them in the system prompt to guide the model.
+
+```yaml
+steps:
+  - step_id: start
+    description: Initial step
+    examples:
+      - context: "User asks for the time"
+        decision: "Answer with the current time."
+        visibility: always
+      - context: "sqrt 4"
+        decision: "Call sqrt tool"
+        visibility: dynamic
+```
+
+Use the `max_examples` and `threshold` settings in `AgentConfig` to control how
+many examples are displayed and the minimum similarity required.
+
 ## External Tool Integration
 
 NOMOS allows you to reference Python package functions, CrewAI tools, and LangChain tools directly in your configuration.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,15 @@
 import pytest
 from typing import List
 from pydantic import BaseModel
-import pytest
 
-from nomos.models.agent import Message, Step, Route
+from nomos.models.agent import (
+    Message,
+    Step,
+    Route,
+    DecisionExample,
+    Decision,
+    Action,
+)
 from nomos.models.tool import ToolWrapper, ToolDef, ArgDef
 from nomos.llms import LLMBase
 from nomos.config import AgentConfig, ToolsConfig
@@ -57,6 +63,18 @@ class MockLLM(LLMBase):
             response.model_json_schema() == response_format.model_json_schema()
         ), f"Response schema mismatch: {response.model_json_schema()} != {response_format.model_json_schema()}"
         return response
+
+    def embed_text(self, text: str) -> List[float]:
+        """Return a simple letter frequency embedding for the given text."""
+        vector = [0.0] * 26
+        for ch in text.lower():
+            if "a" <= ch <= "z":
+                vector[ord(ch) - 97] += 1.0
+        return vector
+
+    def embed_batch(self, texts: List[str]) -> List[List[float]]:
+        """Embed a batch of texts using ``embed_text``."""
+        return [self.embed_text(t) for t in texts]
 
 
 @pytest.fixture
@@ -141,3 +159,49 @@ def basic_agent(mock_llm, basic_steps, test_tool_0, test_tool_1, pkg_tool, tool_
     return Agent.from_config(
         config=config, llm=mock_llm, tools=[test_tool_0, test_tool_1, pkg_tool]
     )
+
+
+@pytest.fixture
+def example_steps():
+    """Steps including decision examples for testing."""
+    example_decision = Decision(
+        reasoning=["example"],
+        action=Action.ANSWER.value,
+        response="Example time",
+    )
+
+    start_step = Step(
+        step_id="start",
+        description="Start with examples",
+        routes=[Route(target="end", condition="done")],
+        available_tools=["test_tool"],
+        examples=[
+            DecisionExample(
+                context="time question",
+                decision=example_decision,
+                visibility="always",
+            ),
+            DecisionExample(
+                context="sqrt 4",
+                decision="Use sqrt tool",
+                visibility="dynamic",
+            ),
+        ],
+    )
+
+    end_step = Step(step_id="end", description="End")
+    return [start_step, end_step]
+
+
+@pytest.fixture
+def example_agent(mock_llm, example_steps, test_tool_0, tool_defs):
+    """Agent instance with steps that include examples."""
+    config = AgentConfig(
+        name="example_agent",
+        persona="Example persona",
+        steps=example_steps,
+        start_step_id="start",
+        max_examples=2,
+        tools=ToolsConfig(tool_defs=tool_defs),
+    )
+    return Agent.from_config(config=config, llm=mock_llm, tools=[test_tool_0])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1198,3 +1198,36 @@ class TestAgentNext:
         assert len(tools) == 3  # Original tools from basic_agent
         tool_names = [tool.name for tool in tools]
         assert "nonexistent_tool" not in tool_names
+
+
+class TestStepExamples:
+    """Tests related to step examples and embeddings."""
+
+    def test_example_embeddings_initialized(self, example_agent):
+        step = example_agent.steps["start"]
+        assert step.examples is not None
+        assert all(ex._ctx_embedding is not None for ex in step.examples)
+
+    def test_examples_in_system_prompt(self, example_agent):
+        session = example_agent.create_session()
+        decision_model = example_agent.llm._create_decision_model(
+            current_step=session.current_step,
+            current_step_tools=session._get_current_step_tools(),
+        )
+
+        response = decision_model(
+            reasoning=["r"], action=Action.ANSWER.value, response="ok"
+        )
+        example_agent.llm.set_response(response)
+        session.next("sqrt 4")
+        system_prompt = session.llm.messages_received[0].content
+        assert "Examples:" in system_prompt
+        assert "time question" in system_prompt
+        assert "sqrt 4" in system_prompt
+
+        session = example_agent.create_session()
+        example_agent.llm.set_response(response)
+        session.next("unrelated input")
+        system_prompt = session.llm.messages_received[0].content
+        assert "time question" in system_prompt
+        assert "sqrt 4" not in system_prompt


### PR DESCRIPTION
## Summary
- document step example usage in README and configuration guide
- extend MockLLM to provide simple embeddings
- add fixtures and tests for step examples

## Testing
- `pip install -e .`
- `pip install pytest-cov typer rich crewai-tools sqlalchemy sqlmodel`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d6db4a6888332b7794bfa9f617bd7