### PR TITLE
Refactor action enum to RESPOND

### DIFF
--- a/cookbook/examples/barista/barista.py
+++ b/cookbook/examples/barista/barista.py
@@ -224,7 +224,7 @@ sess = barista.create_session()
 user_input = None
 while True:
     decision, _ = sess.next(user_input)
-    if decision.action in [Action.ASK, Action.ANSWER]:
+    if decision.action == Action.RESPOND:
         user_input = input(f"Assistant: {decision.response}\nYou: ")
     elif decision.action == Action.END:
         print("Session ended.")

--- a/cookbook/examples/barista/barista_with_config.py
+++ b/cookbook/examples/barista/barista_with_config.py
@@ -18,7 +18,7 @@ sess = barista.create_session()
 user_input = None
 while True:
     decision, _ = sess.next(user_input)
-    if decision.action.value in [Action.ASK.value, Action.ANSWER.value]:
+    if decision.action == Action.RESPOND:
         user_input = input(f"Assistant: {decision.response}\nYou: ")
     elif decision.action.value == Action.END.value:
         print("Session ended.")

--- a/cookbook/examples/financial-advisor/test_agent.py
+++ b/cookbook/examples/financial-advisor/test_agent.py
@@ -8,7 +8,7 @@ from nomos import *
 def test_greets_user(financial_advisor_agent: Agent):
     """Test that the financial advisor agent greets the user."""
     decision, _, _ = financial_advisor_agent.next("Hello")
-    assert decision.action.value == "ASK"
+    assert decision.action.value == "RESPOND"
     smart_assert(decision, "Greets the User", financial_advisor_agent.llm)
 
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -87,7 +87,7 @@ Run the agent interactively and record new decision examples:
 nomos train
 ```
 
-During training, the CLI shows each step transition and tool result. If you're not satisfied with the response, you can provide feedback which will be stored as an example for the current step.
+During training, the CLI shows each step ID and tool result. If you're not satisfied with the response, you can provide feedback which will be stored as an example for the current step.
 
 ## Production Deployment
 

--- a/nomos/api/static/index.html
+++ b/nomos/api/static/index.html
@@ -799,11 +799,11 @@
                             messageElement.appendChild(accordion);
                         }
 
-                        // 2. Step transition
+                        // 2. Step id
                         if (extras.nextStepId) {
                             const stepTransitionHtml = `<p class="text-sm">Transitioning to: <code class="bg-gray-100 px-1 rounded">${escapeHtml(extras.nextStepId)}</code></p>`;
                             const accordion = createAccordion(
-                                'View step transition',
+                                'View step id',
                                 'text-xs text-purple-600 bg-purple-50 hover:bg-purple-100 transition',
                                 stepTransitionHtml
                             );
@@ -1388,7 +1388,7 @@
                     // Create a map to track steps
                     const stepMap = new Map();
 
-                    // First pass: collect step transitions
+                    // First pass: collect step ids
                     sessionData.history.forEach((item, index) => {
                         if (item.step_id) {
                             stepMap.set(index, item.step_id);
@@ -1409,7 +1409,7 @@
                             if (item.role === 'user') {
                                 addMessageToUI('user', item.content);
                             } else if (['assistant', 'system', 'financial_advisor'].includes(item.role)) {
-                                // Check if the next item is a step transition
+                                // Check if the next item is a step id
                                 const nextStepId = stepMap.get(i + 1);
                                 addMessageToUI('assistant', item.content, { nextStepId });
                             } else if (item.role === 'tool') {

--- a/nomos/cli.py
+++ b/nomos/cli.py
@@ -791,10 +791,10 @@ def _train(config_path: Path, tool_files: List[Path]) -> None:
     console.print("Type quit to exit\n")
 
     session_data: Optional[dict] = None
-    last_action: Action = Action.ANSWER
+    last_action: Action = Action.RESPOND
     while True:
         # print(session_data)
-        if last_action in [Action.ANSWER, Action.ASK]:
+        if last_action == Action.RESPOND:
             user_input = Prompt.ask("You").strip()
             if user_input.lower() in {"quit", "exit", "bye"}:
                 break
@@ -803,7 +803,7 @@ def _train(config_path: Path, tool_files: List[Path]) -> None:
         decision, tool_output, session_data = agent.next(
             user_input, session_data, verbose=True
         )
-        if decision.action in [Action.ANSWER, Action.ASK]:
+        if decision.action == Action.RESPOND:
             console.print(
                 "Agent:\nReasoning:{}\nResponse: {}".format(
                     "\n".join(decision.reasoning), decision.response

--- a/nomos/llms/base.py
+++ b/nomos/llms/base.py
@@ -251,7 +251,7 @@ class LLMBase:
         tool_ids = [tool.name for tool in current_step_tools]
         tool_models = [tool.get_args_model() for tool in current_step_tools]
         action_ids = (
-            (["ASK", "ANSWER", "END"] if not current_step.auto_flow else ["END"])
+            (["RESPOND", "END"] if not current_step.auto_flow else ["END"])
             + (["MOVE"] if available_step_ids else [])
             + (["TOOL_CALL"] if tool_ids else [])
         )
@@ -270,11 +270,11 @@ class LLMBase:
                 answer_model = current_step.get_answer_model()
                 response_type = Union.__getitem__((str, answer_model))
                 response_desc = (
-                    f"Response as string if ASK or {answer_model.__name__} if ANSWER."
+                    f"Response as string or {answer_model.__name__} if RESPOND."
                 )
             else:
                 response_type = str
-                response_desc = "Response (String) if ASK or ANSWER."
+                response_desc = "Response (String) if RESPOND."
             params["response"] = {
                 "type": response_type,
                 "description": response_desc,
@@ -284,13 +284,13 @@ class LLMBase:
             if current_step.quick_suggestions:
                 params["suggestions"] = {
                     "type": List[str],
-                    "description": "Quick User Input Suggestions for the User to Choose if ASK.",
+                    "description": "Quick User Input Suggestions for the User to Choose if RESPOND.",
                     "optional": True,
                     "default": None,
                 }
 
         if len(available_step_ids) > 0:
-            params["step_transition"] = {
+            params["step_id"] = {
                 "type": Literal.__getitem__(tuple(available_step_ids)),
                 "description": "Step Id (String) if MOVE.",
                 "optional": True,
@@ -346,9 +346,7 @@ class LLMBase:
             action=output.action.value,
             response=output.response if hasattr(output, "response") else None,
             suggestions=output.suggestions if hasattr(output, "suggestions") else None,
-            step_transition=(
-                output.step_transition if hasattr(output, "step_transition") else None
-            ),
+            step_id=(output.step_id if hasattr(output, "step_id") else None),
             tool_call=(
                 ToolCall(
                     tool_name=output.tool_call.tool_name,

--- a/nomos/models/agent.py
+++ b/nomos/models/agent.py
@@ -28,15 +28,13 @@ class Action(Enum):
 
     Attributes:
         MOVE: Transition to another step.
-        ANSWER: Provide an answer to the user.
-        ASK: Ask the user for input.
+        RESPOND: Provide or request information from the user.
         TOOL_CALL: Call a tool with arguments.
         END: End the flow.
     """
 
     MOVE = "MOVE"
-    ANSWER = "ANSWER"
-    ASK = "ASK"
+    RESPOND = "RESPOND"
     TOOL_CALL = "TOOL_CALL"
     END = "END"
 
@@ -302,9 +300,9 @@ class Decision(BaseModel):
     Attributes:
         reasoning (List[str]): Step by step reasoning to decide.
         action (Action): The next action to take.
-        response (Optional[Union[str, BaseModel]]): Response if ASK or ANSWER.
-        suggestions (Optional[List[str]]): Quick user input suggestions if ASK.
-        step_transition (Optional[str]): Step ID to transition to if MOVE.
+        response (Optional[Union[str, BaseModel]]): Response if RESPOND.
+        suggestions (Optional[List[str]]): Quick user input suggestions if RESPOND.
+        step_id (Optional[str]): Step ID to transition to if MOVE.
         tool_call (Optional[Dict[str, Any]]): Tool call details if TOOL_CALL.
     """
 
@@ -312,17 +310,15 @@ class Decision(BaseModel):
     action: Action
     response: Optional[Union[str, BaseModel]] = None
     suggestions: Optional[List[str]] = None
-    step_transition: Optional[str] = None
+    step_id: Optional[str] = None
     tool_call: Optional[ToolCall] = None
 
     def __str__(self) -> str:
         """Return a string representation of the decision."""
-        if self.action in [Action.ANSWER, Action.ASK]:
+        if self.action == Action.RESPOND:
             return f"action: {self.action.value}, response: {self.response}"
         elif self.action == Action.MOVE:
-            return (
-                f"action: {self.action.value}, step_transition: {self.step_transition}"
-            )
+            return f"action: {self.action.value}, step_id: {self.step_id}"
         elif self.action == Action.TOOL_CALL and self.tool_call:
             return f"action: {self.action.value}, tool_call: {self.tool_call.tool_name} with args {self.tool_call.tool_kwargs.model_dump_json()}"
         elif self.action == Action.END:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,7 +166,7 @@ def example_steps():
     """Steps including decision examples for testing."""
     example_decision = Decision(
         reasoning=["example"],
-        action=Action.ANSWER.value,
+        action=Action.RESPOND.value,
         response="Example time",
     )
 


### PR DESCRIPTION
## Summary
- replace ASK/ANSWER actions with RESPOND action
- rename decision field `step_transition` to `step_id`
- update core, CLI and LLM logic for RESPOND and step_id
- adjust examples, tests and docs

## Testing
- `pre-commit run --files cookbook/examples/barista/barista.py cookbook/examples/barista/barista_with_config.py cookbook/examples/financial-advisor/test_agent.py docs/cli-usage.md nomos/api/static/index.html nomos/cli.py nomos/core.py nomos/llms/base.py nomos/models/agent.py tests/conftest.py tests/test_core.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f9b0096f48332b4c08df64e6c631a