### PR TITLE
Refactor action enum to RESPOND

### DIFF
--- a/cookbook/examples/barista/barista.py
+++ b/cookbook/examples/barista/barista.py
@@ -224,7 +224,7 @@ sess = barista.create_session()
 user_input = None
 while True:
     decision, _ = sess.next(user_input)
-    if decision.action in [Action.ASK, Action.ANSWER]:
+    if decision.action == Action.RESPOND:
         user_input = input(f"Assistant: {decision.response}\nYou: ")
     elif decision.action == Action.END:
         print("Session ended.")

--- a/cookbook/examples/barista/barista_with_config.py
+++ b/cookbook/examples/barista/barista_with_config.py
@@ -18,7 +18,7 @@ sess = barista.create_session()
 user_input = None
 while True:
     decision, _ = sess.next(user_input)
-    if decision.action.value in [Action.ASK.value, Action.ANSWER.value]:
+    if decision.action == Action.RESPOND:
         user_input = input(f"Assistant: {decision.response}\nYou: ")
     elif decision.action.value == Action.END.value:
         print("Session ended.")

--- a/cookbook/examples/financial-advisor/test_agent.py
+++ b/cookbook/examples/financial-advisor/test_agent.py
@@ -8,7 +8,7 @@ from nomos import *
 def test_greets_user(financial_advisor_agent: Agent):
     """Test that the financial advisor agent greets the user."""
     decision, _, _ = financial_advisor_agent.next("Hello")
-    assert decision.action.value == "ASK"
+    assert decision.action.value == "RESPOND"
     smart_assert(decision, "Greets the User", financial_advisor_agent.llm)
 
 

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -87,7 +87,7 @@ Run the agent interactively and record new decision examples:
 nomos train
 ```
 
-During training, the CLI shows each step transition and tool result. If you're not satisfied with the response, you can provide feedback which will be stored as an example for the current step.
+During training, the CLI shows each step ID and tool result. If you're not satisfied with the response, you can provide feedback which will be stored as an example for the current step.
 
 ## Production Deployment
 

--- a/nomos/api/static/index.html
+++ b/nomos/api/static/index.html
@@ -799,11 +799,11 @@
                             messageElement.appendChild(accordion);
                         }
 
-                        // 2. Step transition
+                        // 2. Step id
                         if (extras.nextStepId) {
                             const stepTransitionHtml = `<p class="text-sm">Transitioning to: <code class="bg-gray-100 px-1 rounded">${escapeHtml(extras.nextStepId)}</code></p>`;
                             const accordion = createAccordion(
-                                'View step transition',
+                                'View step id',
                                 'text-xs text-purple-600 bg-purple-50 hover:bg-purple-100 transition',
                                 stepTransitionHtml
                             );
@@ -1388,7 +1388,7 @@
                     // Create a map to track steps
                     const stepMap = new Map();
 
-                    // First pass: collect step transitions
+                    // First pass: collect step ids
                     sessionData.history.forEach((item, index) => {
                         if (item.step_id) {
                             stepMap.set(index, item.step_id);
@@ -1409,7 +1409,7 @@
                             if (item.role === 'user') {
                                 addMessageToUI('user', item.content);
                             } else if (['assistant', 'system', 'financial_advisor'].includes(item.role)) {
-                                // Check if the next item is a step transition
+                                // Check if the next item is a step id
                                 const nextStepId = stepMap.get(i + 1);
                                 addMessageToUI('assistant', item.content, { nextStepId });
                             } else if (item.role === 'tool') {

--- a/nomos/cli.py
+++ b/nomos/cli.py
@@ -791,10 +791,10 @@ def _train(config_path: Path, tool_files: List[Path]) -> None:
     console.print("Type quit to exit\n")
 
     session_data: Optional[dict] = None
-    last_action: Action = Action.ANSWER
+    last_action: Action = Action.RESPOND
     while True:
         # print(session_data)
-        if last_action in [Action.ANSWER, Action.ASK]:
+        if last_action == Action.RESPOND:
             user_input = Prompt.ask("You").strip()
             if user_input.lower() in {"quit", "exit", "bye"}:
                 break
@@ -803,7 +803,7 @@ def _train(config_path: Path, tool_files: List[Path]) -> None:
         decision, tool_output, session_data = agent.next(
             user_input, session_data, verbose=True
         )
-        if decision.action in [Action.ANSWER, Action.ASK]:
+        if decision.action == Action.RESPOND:
             console.print(
                 "Agent:\nReasoning:{}\nResponse: {}".format(
                     "\n".join(decision.reasoning), decision.response

--- a/nomos/core.py
+++ b/nomos/core.py
@@ -242,7 +242,7 @@ class Session:
         no_errors: int = 0,
         next_count: int = 0,
         return_tool: bool = False,
-        return_step_transition: bool = False,
+        return_step_id: bool = False,
     ) -> tuple[Decision, Any]:
         """
         Advance the session to the next step based on user input and LLM decision.
@@ -251,7 +251,7 @@ class Session:
         :param no_errors: Number of consecutive errors encountered.
         :param next_count: Number of times the next function has been called.
         :param return_tool: Whether to return tool results.
-        :param return_step_transition: Whether to return step transition.
+        :param return_step_id: Whether to return step id.
         :return: A tuple containing the decision and any tool results.
         """
         if no_errors >= self.max_errors:
@@ -286,8 +286,25 @@ class Session:
         log_info(str(decision)) if self.verbose else log_debug(str(decision))
         log_debug(f"Action decided: {decision.action}")
 
+        if decision.action == Action.RESPOND and decision.response is None:
+            self._add_message(
+                "error", "RESPOND action requires a response, but none was provided."
+            )
+            return self.next(
+                no_errors=no_errors + 1,
+                next_count=next_count + 1,
+            )
+        if decision.action == Action.MOVE and decision.step_id is None:
+            self._add_message(
+                "error", "MOVE action requires a step_id, but none was provided."
+            )
+            return self.next(
+                no_errors=no_errors + 1,
+                next_count=next_count + 1,
+            )
+
         self._add_step_identifier(self.current_step.get_step_identifier())
-        if decision.action in [Action.ASK, Action.ANSWER]:
+        if decision.action == Action.RESPOND:
             self._add_message(self.name, str(decision.response))
             return decision, None
         elif decision.action == Action.TOOL_CALL:
@@ -322,10 +339,10 @@ class Session:
                 no_errors=no_errors + 1 if _error else 0,
                 next_count=next_count + 1,
             )
-        elif decision.action == Action.MOVE and decision.step_transition:
+        elif decision.action == Action.MOVE and decision.step_id:
             _error = None
             if self.state_machine.can_transition(
-                self.state_machine.current_step_id, decision.step_transition
+                self.state_machine.current_step_id, decision.step_id
             ):
                 # Check if we need to exit current flow before moving
                 if self.state_machine.current_flow and self.state_machine.flow_context:
@@ -337,7 +354,7 @@ class Session:
                             self.state_machine.current_step_id
                         )
 
-                self.state_machine.move(decision.step_transition)
+                self.state_machine.move(decision.step_id)
                 log_debug(f"Moving to next step: {self.state_machine.current_step_id}")
                 self._add_step_identifier(self.current_step.get_step_identifier())
 
@@ -352,12 +369,12 @@ class Session:
                 )
                 self._add_message(
                     "error",
-                    f"Invalid route: {decision.step_transition} not in {allowed}",
+                    f"Invalid route: {decision.step_id} not in {allowed}",
                 )
                 _error = ValueError(
-                    f"Invalid route: {decision.step_transition} not in {allowed}"
+                    f"Invalid route: {decision.step_id} not in {allowed}"
                 )
-            if return_step_transition:
+            if return_step_id:
                 return decision, None
             return self.next(
                 no_errors=no_errors + 1 if _error else 0,
@@ -673,7 +690,7 @@ class Agent:
             else self.create_session()
         )
         decision, tool_output = session.next(
-            user_input=user_input, return_tool=verbose, return_step_transition=verbose
+            user_input=user_input, return_tool=verbose, return_step_id=verbose
         )
         return decision, tool_output, session.get_state()
 

--- a/nomos/llms/base.py
+++ b/nomos/llms/base.py
@@ -251,7 +251,7 @@ class LLMBase:
         tool_ids = [tool.name for tool in current_step_tools]
         tool_models = [tool.get_args_model() for tool in current_step_tools]
         action_ids = (
-            (["ASK", "ANSWER", "END"] if not current_step.auto_flow else ["END"])
+            (["RESPOND", "END"] if not current_step.auto_flow else ["END"])
             + (["MOVE"] if available_step_ids else [])
             + (["TOOL_CALL"] if tool_ids else [])
         )
@@ -270,11 +270,11 @@ class LLMBase:
                 answer_model = current_step.get_answer_model()
                 response_type = Union.__getitem__((str, answer_model))
                 response_desc = (
-                    f"Response as string if ASK or {answer_model.__name__} if ANSWER."
+                    f"Response as string or {answer_model.__name__} if RESPOND."
                 )
             else:
                 response_type = str
-                response_desc = "Response (String) if ASK or ANSWER."
+                response_desc = "Response (String) if RESPOND."
             params["response"] = {
                 "type": response_type,
                 "description": response_desc,
@@ -284,13 +284,13 @@ class LLMBase:
             if current_step.quick_suggestions:
                 params["suggestions"] = {
                     "type": List[str],
-                    "description": "Quick User Input Suggestions for the User to Choose if ASK.",
+                    "description": "Quick User Input Suggestions for the User to Choose if RESPOND.",
                     "optional": True,
                     "default": None,
                 }
 
         if len(available_step_ids) > 0:
-            params["step_transition"] = {
+            params["step_id"] = {
                 "type": Literal.__getitem__(tuple(available_step_ids)),
                 "description": "Step Id (String) if MOVE.",
                 "optional": True,
@@ -346,9 +346,7 @@ class LLMBase:
             action=output.action.value,
             response=output.response if hasattr(output, "response") else None,
             suggestions=output.suggestions if hasattr(output, "suggestions") else None,
-            step_transition=(
-                output.step_transition if hasattr(output, "step_transition") else None
-            ),
+            step_id=(output.step_id if hasattr(output, "step_id") else None),
             tool_call=(
                 ToolCall(
                     tool_name=output.tool_call.tool_name,

--- a/nomos/models/agent.py
+++ b/nomos/models/agent.py
@@ -28,15 +28,13 @@ class Action(Enum):
 
     Attributes:
         MOVE: Transition to another step.
-        ANSWER: Provide an answer to the user.
-        ASK: Ask the user for input.
+        RESPOND: Provide or request information from the user.
         TOOL_CALL: Call a tool with arguments.
         END: End the flow.
     """
 
     MOVE = "MOVE"
-    ANSWER = "ANSWER"
-    ASK = "ASK"
+    RESPOND = "RESPOND"
     TOOL_CALL = "TOOL_CALL"
     END = "END"
 
@@ -302,9 +300,9 @@ class Decision(BaseModel):
     Attributes:
         reasoning (List[str]): Step by step reasoning to decide.
         action (Action): The next action to take.
-        response (Optional[Union[str, BaseModel]]): Response if ASK or ANSWER.
-        suggestions (Optional[List[str]]): Quick user input suggestions if ASK.
-        step_transition (Optional[str]): Step ID to transition to if MOVE.
+        response (Optional[Union[str, BaseModel]]): Response if RESPOND.
+        suggestions (Optional[List[str]]): Quick user input suggestions if RESPOND.
+        step_id (Optional[str]): Step ID to transition to if MOVE.
         tool_call (Optional[Dict[str, Any]]): Tool call details if TOOL_CALL.
     """
 
@@ -312,17 +310,15 @@ class Decision(BaseModel):
     action: Action
     response: Optional[Union[str, BaseModel]] = None
     suggestions: Optional[List[str]] = None
-    step_transition: Optional[str] = None
+    step_id: Optional[str] = None
     tool_call: Optional[ToolCall] = None
 
     def __str__(self) -> str:
         """Return a string representation of the decision."""
-        if self.action in [Action.ANSWER, Action.ASK]:
+        if self.action == Action.RESPOND:
             return f"action: {self.action.value}, response: {self.response}"
         elif self.action == Action.MOVE:
-            return (
-                f"action: {self.action.value}, step_transition: {self.step_transition}"
-            )
+            return f"action: {self.action.value}, step_id: {self.step_id}"
         elif self.action == Action.TOOL_CALL and self.tool_call:
             return f"action: {self.action.value}, tool_call: {self.tool_call.tool_name} with args {self.tool_call.tool_kwargs.model_dump_json()}"
         elif self.action == Action.END:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,7 +166,7 @@ def example_steps():
     """Steps including decision examples for testing."""
     example_decision = Decision(
         reasoning=["example"],
-        action=Action.ANSWER.value,
+        action=Action.RESPOND.value,
         response="Example time",
     )
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -71,7 +71,7 @@ def test_basic_conversation_flow(basic_agent, test_tool_0, test_tool_1, tool_def
         ],
     )
     ask_response = expected_decision_model(
-        reasoning=["Greeting"], action=Action.ASK.value, response="How can I help?"
+        reasoning=["Greeting"], action=Action.RESPOND.value, response="How can I help?"
     )
 
     assert session.current_step.get_available_routes() == ["end"]
@@ -90,12 +90,12 @@ def test_basic_conversation_flow(basic_agent, test_tool_0, test_tool_1, tool_def
     assert session.llm.messages_received[0].role == "system"
     assert "Test persona" in session.llm.messages_received[0].content
     assert session.llm.messages_received[1].role == "user"
-    assert decision.action == Action.ASK
+    assert decision.action == Action.RESPOND
     assert decision.response == "How can I help?"
 
     ask_response = expected_decision_model(
         reasoning=["User input"],
-        action=Action.ANSWER.value,
+        action=Action.RESPOND.value,
         response="I can help you with that.",
     )
     session.llm.set_response(ask_response)
@@ -105,7 +105,7 @@ def test_basic_conversation_flow(basic_agent, test_tool_0, test_tool_1, tool_def
     assert session.llm.messages_received[1].role == "user"
     assert "How can I help?" in session.llm.messages_received[1].content
     assert "I need help" in session.llm.messages_received[1].content
-    assert decision.action == Action.ANSWER
+    assert decision.action == Action.RESPOND
     assert decision.response == "I can help you with that."
 
 
@@ -467,15 +467,15 @@ class TestStepTransitions:
 
         # Mock decision for valid move
         valid_decision = Decision(
-            reasoning=["Move to end"], action=Action.MOVE, step_transition="end"
+            reasoning=["Move to end"], action=Action.MOVE, step_id="end"
         )
 
         with patch.object(session, "_get_next_decision", return_value=valid_decision):
             initial_step = session.current_step.step_id
-            decision, _ = session.next("Move to end", return_step_transition=True)
+            decision, _ = session.next("Move to end", return_step_id=True)
 
             assert decision.action == Action.MOVE
-            assert decision.step_transition == "end"
+            assert decision.step_id == "end"
             assert session.current_step.step_id == "end"
             assert session.current_step.step_id != initial_step
 
@@ -633,15 +633,13 @@ class TestUnknownActionHandling:
         session = basic_agent.create_session()
 
         # Test that Action enum has expected values
-        assert hasattr(Action, "ASK")
-        assert hasattr(Action, "ANSWER")
+        assert hasattr(Action, "RESPOND")
         assert hasattr(Action, "END")
         assert hasattr(Action, "MOVE")
         assert hasattr(Action, "TOOL_CALL")
 
         # Test string values
-        assert Action.ASK.value == "ASK"
-        assert Action.ANSWER.value == "ANSWER"
+        assert Action.RESPOND.value == "RESPOND"
         assert Action.END.value == "END"
         assert Action.MOVE.value == "MOVE"
         assert Action.TOOL_CALL.value == "TOOL_CALL"
@@ -674,7 +672,7 @@ class TestMaxIterationsBehavior:
 
         fallback_response = decision_model(
             reasoning=["Providing fallback response"],
-            action=Action.ANSWER.value,
+            action=Action.RESPOND.value,
             response="I apologize, but I've reached the maximum number of attempts.",
         )
         basic_agent.llm.set_response(fallback_response)
@@ -687,7 +685,7 @@ class TestMaxIterationsBehavior:
         fallback_msgs = [msg for msg in messages if msg.role == "fallback"]
         assert len(fallback_msgs) == 1
         assert "Maximum iterations reached" in fallback_msgs[0].content
-        assert decision.action == Action.ANSWER
+        assert decision.action == Action.RESPOND
 
 
 class TestToolExecutionScenarios:
@@ -935,15 +933,13 @@ class TestAdvancedErrorHandling:
     def test_unknown_action_error(self, basic_agent):
         """Test error handling for unknown actions."""
         # Test that the Action enum has expected values
-        assert hasattr(Action, "ASK")
-        assert hasattr(Action, "ANSWER")
+        assert hasattr(Action, "RESPOND")
         assert hasattr(Action, "END")
         assert hasattr(Action, "MOVE")
         assert hasattr(Action, "TOOL_CALL")
 
         # Test string values
-        assert Action.ASK.value == "ASK"
-        assert Action.ANSWER.value == "ANSWER"
+        assert Action.RESPOND.value == "RESPOND"
         assert Action.END.value == "END"
         assert Action.MOVE.value == "MOVE"
         assert Action.TOOL_CALL.value == "TOOL_CALL"
@@ -962,6 +958,52 @@ class TestAdvancedErrorHandling:
         # Test tool with valid arguments works
         result = tool.run(arg0="test")
         assert "test" in result
+
+    def test_missing_response_and_step_id_handling(self, basic_agent):
+        """Ensure missing decision fields trigger retry with error message."""
+        session = basic_agent.create_session()
+
+        decision_model = basic_agent.llm._create_decision_model(
+            current_step=session.current_step,
+            current_step_tools=session._get_current_step_tools(),
+        )
+
+        invalid_resp = decision_model(reasoning=["r"], action=Action.RESPOND.value)
+        valid_resp = decision_model(
+            reasoning=["r"], action=Action.RESPOND.value, response="ok"
+        )
+        basic_agent.llm.set_response(invalid_resp)
+        basic_agent.llm.set_response(valid_resp, append=True)
+
+        decision, _ = session.next()
+
+        assert decision.action == Action.RESPOND
+        assert decision.response == "ok"
+        messages = [msg for msg in session.memory.context if isinstance(msg, Message)]
+        assert any("requires a response" in msg.content for msg in messages)
+
+        move_model = decision_model
+        invalid_move = move_model(reasoning=["m"], action=Action.MOVE.value)
+        valid_move = move_model(
+            reasoning=["m"], action=Action.MOVE.value, step_id="end"
+        )
+        end_model = basic_agent.llm._create_decision_model(
+            current_step=basic_agent.steps["end"],
+            current_step_tools=[],
+        )
+        end_decision = end_model(
+            reasoning=["done"], action=Action.END.value, response="bye"
+        )
+
+        basic_agent.llm.set_response(invalid_move)
+        basic_agent.llm.set_response(valid_move, append=True)
+        basic_agent.llm.set_response(end_decision, append=True)
+
+        decision, _ = session.next()
+
+        assert decision.action == Action.END
+        messages = [msg for msg in session.memory.context if isinstance(msg, Message)]
+        assert any("step_id" in msg.content for msg in messages)
 
 
 class TestAgentValidationExtended:
@@ -1162,7 +1204,7 @@ class TestAgentNext:
 
         response = decision_model(
             reasoning=["Respond to greeting"],
-            action=Action.ANSWER.value,
+            action=Action.RESPOND.value,
             response="Hello there!",
         )
         basic_agent.llm.set_response(response)
@@ -1171,7 +1213,7 @@ class TestAgentNext:
             user_input="Hello", session_data=session_context, verbose=True
         )
 
-        assert decision.action == Action.ANSWER
+        assert decision.action == Action.RESPOND
         assert hasattr(session_data, "session_id")
         assert hasattr(session_data, "current_step_id")
 
@@ -1187,14 +1229,14 @@ class TestAgentNext:
 
         response = decision_model(
             reasoning=["Initial response"],
-            action=Action.ASK.value,
+            action=Action.RESPOND.value,
             response="How can I help?",
         )
         basic_agent.llm.set_response(response)
 
         decision, tool_output, session_data = basic_agent.next("Hello")
 
-        assert decision.action == Action.ASK
+        assert decision.action == Action.RESPOND
         assert hasattr(session_data, "session_id")
         assert session_data.current_step_id == "start"
 
@@ -1230,7 +1272,7 @@ class TestStepExamples:
         )
 
         response = decision_model(
-            reasoning=["r"], action=Action.ANSWER.value, response="ok"
+            reasoning=["r"], action=Action.RESPOND.value, response="ok"
         )
         example_agent.llm.set_response(response)
         session.next("sqrt 4")


### PR DESCRIPTION
## Summary
- replace ASK/ANSWER actions with RESPOND action
- rename decision field `step_transition` to `step_id`
- update core, CLI and LLM logic for RESPOND and step_id
- adjust examples, tests and docs
- handle missing RESPOND/MOVE fields with retry logic

## Testing
- `pre-commit run --files nomos/core.py tests/test_core.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f9b0096f48332b4c08df64e6c631a